### PR TITLE
refactor database access and peer discovery

### DIFF
--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -11,14 +11,12 @@ import (
 	"github.com/blocklessnetworking/b7s/src/messaging"
 	"github.com/blocklessnetworking/b7s/src/models"
 	"github.com/blocklessnetworking/b7s/src/repository"
-	"github.com/cockroachdb/pebble"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	log "github.com/sirupsen/logrus"
 )
 
 func IsFunctionInstalled(ctx context.Context, functionId string) (models.FunctionManifest, error) {
-	appDb := ctx.Value("appDb").(*pebble.DB)
-	functionManifestString, err := db.Value(appDb, functionId)
+	functionManifestString, err := db.GetString(ctx, functionId)
 	functionManifest := models.FunctionManifest{}
 
 	json.Unmarshal([]byte(functionManifestString), &functionManifest)

--- a/src/dht/dht.go
+++ b/src/dht/dht.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/blocklessnetworking/b7s/src/db"
 	"github.com/blocklessnetworking/b7s/src/models"
 	"github.com/libp2p/go-libp2p-core/peer"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
@@ -64,7 +63,8 @@ func InitDHT(ctx context.Context, h host.Host) *dht.IpfsDHT {
 	return kademliaDHT
 }
 
-func DiscoverPeers(ctx context.Context, h host.Host, topicName string) {
+func DiscoverPeers(ctx context.Context, h host.Host) {
+	topicName := ctx.Value("topicName").(string)
 	kademliaDHT := InitDHT(ctx, h)
 	routingDiscovery := drouting.NewRoutingDiscovery(kademliaDHT)
 	dutil.Advertise(ctx, routingDiscovery, topicName)
@@ -86,11 +86,9 @@ func DiscoverPeers(ctx context.Context, h host.Host, topicName string) {
 				// this can be quite noisy with discovery
 				// fmt.Println("Failed connecting to ", peer.ID.Pretty(), ", error:", err)
 			} else {
-				pebble := db.Get(peer.ID.Pretty())
-				db.Set(pebble, "peerID", peer.ID.Pretty())
 				log.WithFields(log.Fields{
 					"peerID": peer.ID.Pretty(),
-				}).Info("connected to peer")
+				}).Info("connected to a peer")
 				anyConnected = true
 			}
 		}

--- a/src/host/notifee.go
+++ b/src/host/notifee.go
@@ -1,0 +1,54 @@
+package host
+
+import (
+	"context"
+	"log"
+
+	db "github.com/blocklessnetworking/b7s/src/db"
+	"github.com/libp2p/go-libp2p/core/network"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+type ConnectedNotifee struct {
+	Ctx context.Context
+}
+
+// Implement the Connected/Disconnected methods of the Notifee interface
+func (n *ConnectedNotifee) Connected(network network.Network, connection network.Conn) {
+	// log.Info("Connected to: ", connection.RemoteMultiaddr(), connection.RemotePeer())
+	// a peer has connected take the multiaddress and the peer id and store it in pebbleDB
+	// if the peer is already in the database, update the last seen time
+	// if the peer is not in the database, add it
+
+	// get the peer id
+	peerID := connection.RemotePeer()
+	// get the multiaddress
+	multiAddr := connection.RemoteMultiaddr()
+	peerRecord, err := db.Get(n.Ctx, peerID.Pretty())
+
+	if err != nil {
+		log.Println(err)
+	}
+
+	if peerRecord == nil {
+		// peer is not in the database, add it
+		db.Set(n.Ctx, peerID.Pretty(), multiAddr.String())
+	}
+
+	log.Println("Connected to: ", multiAddr, peerID)
+}
+
+func (n *ConnectedNotifee) Disconnected(network network.Network, connection network.Conn) {
+	// A peer has been disconnected
+	// Do something with the disconnected peer
+}
+
+func (n *ConnectedNotifee) Listen(network.Network, ma.Multiaddr) {
+	// A new stream has been opened
+	// Do something with the stream
+}
+
+func (n *ConnectedNotifee) ListenClose(network.Network, ma.Multiaddr) {
+	// A stream has been closed
+	// Do something with the closed stream
+}

--- a/src/repository/repository.go
+++ b/src/repository/repository.go
@@ -15,7 +15,6 @@ import (
 	"github.com/blocklessnetworking/b7s/src/db"
 	"github.com/blocklessnetworking/b7s/src/http"
 	"github.com/blocklessnetworking/b7s/src/models"
-	"github.com/cockroachdb/pebble"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -49,8 +48,7 @@ func (r JSONRepository) Get(ctx context.Context, manifestPath string) models.Fun
 		functionManifest.Function.ID = strings.Split(u.Hostname(), ".")[0]
 	}
 
-	appDb := ctx.Value("appDb").(*pebble.DB)
-	cachedFunction, err := db.Value(appDb, functionManifest.Function.ID)
+	cachedFunction, err := db.GetString(ctx, functionManifest.Function.ID)
 	WorkSpaceDirectory := WorkSpaceRoot + "/" + functionManifest.Function.ID
 
 	if err != nil {
@@ -79,7 +77,7 @@ func (r JSONRepository) Get(ctx context.Context, manifestPath string) models.Fun
 			log.Warn(error)
 		}
 
-		db.Set(appDb, functionManifest.Function.ID, string(functionManifestJson))
+		db.Set(ctx, functionManifest.Function.ID, string(functionManifestJson))
 
 		log.WithFields(log.Fields{
 			"uri": functionManifest.Deployment.Uri,


### PR DESCRIPTION
In controller.go, the IsFunctionInstalled function has been modified to use the db.GetString function instead of the db.Value function to get the value for a given key in the database. In addition, the functionManifestString variable has been renamed to functionManifest.

In daemon.go, a new libp2p host is created using the host.NewHost function and stored in the context with the key "host". The ConnectedNotifee struct is created and registered with the host's network using the Notify method. The db.Get function has been replaced with the db.GetDb function, and the DiscoverPeers function now takes an additional argument.

In db.go, the Get function has been renamed to GetDb and now returns a *pebble.DB pointer instead of a pebble.DB value. The Value function has been removed and the GetString function has been added.