### PR TITLE
Function Install handling tweak - request timeout support

### DIFF
--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -2,10 +2,8 @@ package controller
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/blocklessnetworking/b7s/src/db"
 	"github.com/blocklessnetworking/b7s/src/enums"
@@ -44,33 +42,6 @@ func ExecuteFunction(ctx context.Context, request models.RequestExecute) (models
 	} else {
 		return HeadExecuteFunction(ctx, request)
 	}
-}
-
-// sub and pub the install
-func MsgInstallFunction(ctx context.Context, installRequest models.RequestFunctionInstall) {
-	var manifestURL string
-
-	switch {
-	case installRequest.Uri != "":
-		manifestURL = installRequest.Uri
-		h := sha256.New()
-		h.Write([]byte(installRequest.Uri))
-		installRequest.Cid = fmt.Sprintf("%x", h.Sum(nil))
-	case installRequest.Cid != "":
-		manifestURL = fmt.Sprintf("https://%s.ipfs.w3s.link/manifest.json", installRequest.Cid)
-	default:
-		log.Error("Neither URI nor CID provided in install request")
-		return
-	}
-
-	msg := models.MsgInstallFunction{
-		Type:        enums.MsgInstallFunction,
-		ManifestUrl: manifestURL,
-		Cid:         installRequest.Cid,
-	}
-
-	log.Info("Requesting to message peer for function installation", msg.ManifestUrl)
-	messaging.PublishMessage(ctx, ctx.Value("topic").(*pubsub.Topic), msg)
 }
 
 func InstallFunction(ctx context.Context, installMessage models.MsgInstallFunction) error {

--- a/src/controller/install_function.go
+++ b/src/controller/install_function.go
@@ -38,7 +38,7 @@ func MsgInstallFunction(ctx context.Context, req models.RequestFunctionInstall) 
 	// Get the pubsub topic from the context.
 	topic, ok := ctx.Value("topic").(*pubsub.Topic)
 	if !ok {
-		return fmt.Errorf("unexpected value for pubsub topic (got: %T)", topic)
+		return errors.New("could not get pubsub topic from context")
 	}
 
 	// Write the message to pubsub topic.

--- a/src/controller/install_function.go
+++ b/src/controller/install_function.go
@@ -1,0 +1,80 @@
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/blocklessnetworking/b7s/src/enums"
+	"github.com/blocklessnetworking/b7s/src/messaging"
+	"github.com/blocklessnetworking/b7s/src/models"
+)
+
+// MsgInstallFunction publishes the function install message to pubsub.
+func MsgInstallFunction(ctx context.Context, req models.RequestFunctionInstall) error {
+
+	if req.Uri == "" && req.Cid == "" {
+		return errors.New("invalid request - URI and CID are empty")
+	}
+
+	var msg models.MsgInstallFunction
+	if req.Uri != "" {
+		var err error
+		msg, err = createInstallMessageFromURI(req.Uri)
+		if err != nil {
+			return fmt.Errorf("could not create install message from URI: %W", err)
+		}
+	} else {
+		msg = createInstallMessageFromCID(req.Cid)
+	}
+
+	log.WithField("url", msg.ManifestUrl).
+		Info("Requesting to message peer for function installation")
+
+	// Get the pubsub topic from the context.
+	topic, ok := ctx.Value("topic").(*pubsub.Topic)
+	if !ok {
+		return fmt.Errorf("unexpected value for pubsub topic (got: %T)", topic)
+	}
+
+	// Write the message to pubsub topic.
+	messaging.PublishMessage(ctx, topic, msg)
+
+	return nil
+}
+
+// createInstallMessageFromURI creates a MsgInstallFunction from the given URI.
+// CID is calculated as a SHA-256 hash of the URI.
+func createInstallMessageFromURI(uri string) (models.MsgInstallFunction, error) {
+
+	h := sha256.New()
+	_, err := h.Write([]byte(uri))
+	if err != nil {
+		return models.MsgInstallFunction{}, fmt.Errorf("could not calculate hash: %w", err)
+	}
+	cid := fmt.Sprintf("%x", h.Sum(nil))
+
+	msg := models.MsgInstallFunction{
+		Type:        enums.MsgInstallFunction,
+		ManifestUrl: uri,
+		Cid:         cid,
+	}
+
+	return msg, nil
+}
+
+// createInstallMessageFromCID creates the MsgInstallFunction from the given CID.
+func createInstallMessageFromCID(cid string) models.MsgInstallFunction {
+
+	msg := models.MsgInstallFunction{
+		Type:        enums.MsgInstallFunction,
+		ManifestUrl: fmt.Sprintf("https://%s.ipfs.w3s.link/manifest.json", cid),
+		Cid:         cid,
+	}
+
+	return msg
+}

--- a/src/controller/install_function.go
+++ b/src/controller/install_function.go
@@ -51,12 +51,10 @@ func MsgInstallFunction(ctx context.Context, req models.RequestFunctionInstall) 
 // CID is calculated as a SHA-256 hash of the URI.
 func createInstallMessageFromURI(uri string) (models.MsgInstallFunction, error) {
 
-	h := sha256.New()
-	_, err := h.Write([]byte(uri))
+	cid, err := deriveCIDFromURI(uri)
 	if err != nil {
-		return models.MsgInstallFunction{}, fmt.Errorf("could not calculate hash: %w", err)
+		return models.MsgInstallFunction{}, fmt.Errorf("could not determine cid: %w", err)
 	}
-	cid := fmt.Sprintf("%x", h.Sum(nil))
 
 	msg := models.MsgInstallFunction{
 		Type:        enums.MsgInstallFunction,
@@ -65,6 +63,18 @@ func createInstallMessageFromURI(uri string) (models.MsgInstallFunction, error) 
 	}
 
 	return msg, nil
+}
+
+func deriveCIDFromURI(uri string) (string, error) {
+
+	h := sha256.New()
+	_, err := h.Write([]byte(uri))
+	if err != nil {
+		return "", fmt.Errorf("could not calculate hash: %w", err)
+	}
+	cid := fmt.Sprintf("%x", h.Sum(nil))
+
+	return cid, nil
 }
 
 // createInstallMessageFromCID creates the MsgInstallFunction from the given CID.

--- a/src/controller/install_function_test.go
+++ b/src/controller/install_function_test.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/src/enums"
+)
+
+func TestCreateInstallMessageFromURI(t *testing.T) {
+
+	const (
+		uri = "https://example.com/manifest.json"
+	)
+
+	req, err := createInstallMessageFromURI(uri)
+	require.NoError(t, err)
+
+	assert.Equal(t, enums.MsgInstallFunction, req.Type)
+	assert.Equal(t, uri, req.ManifestUrl)
+
+	cid, err := deriveCIDFromURI(uri)
+	require.NoError(t, err)
+
+	assert.Equal(t, cid, req.Cid)
+}
+
+func TestCreateInstallMessageFromCID(t *testing.T) {
+
+	const (
+		cid                 = "test-cid-value"
+		expectedManifestURL = `https://test-cid-value.ipfs.w3s.link/manifest.json`
+	)
+
+	req := createInstallMessageFromCID(cid)
+
+	assert.Equal(t, enums.MsgInstallFunction, req.Type)
+	assert.Equal(t, cid, req.Cid)
+	assert.Equal(t, expectedManifestURL, req.ManifestUrl)
+}

--- a/src/restapi/api.go
+++ b/src/restapi/api.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/blocklessnetworking/b7s/src/controller"
 	"github.com/blocklessnetworking/b7s/src/enums"
 	"github.com/blocklessnetworking/b7s/src/models"
@@ -36,50 +38,70 @@ func handleRequestExecute(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 
-type MsgInstallFunctionFunc func(context.Context, models.RequestFunctionInstall)
+type MsgInstallFunctionFunc func(context.Context, models.RequestFunctionInstall) error
 
 func handleInstallFunction(w http.ResponseWriter, r *http.Request) {
-	// body decode
-	request := models.RequestFunctionInstall{}
 
+	// Make sure that the request body is there.
 	if r.Body == nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	json.NewDecoder(r.Body).Decode(&request)
+	// Unmarshal request.
+	var request models.RequestFunctionInstall
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
+	// TODO: Could be done using validators.
 	if request.Uri == "" && request.Cid == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	// get the MsgInstallFunction function from the context
-	var msgInstallFunc MsgInstallFunctionFunc
-	if r.Context().Value("msgInstallFunc") == nil {
-		msgInstallFunc = controller.MsgInstallFunction
-	} else {
-		msgInstallFunc = r.Context().Value("msgInstallFunc").(func(context.Context, models.RequestFunctionInstall))
+	// Initialize the msgInstallFunction function - get the value from the context if set,
+	// else use the default one.
+	var msgInstallFunc MsgInstallFunctionFunc = controller.MsgInstallFunction
+
+	// NOTE: At the moment, this function is no longer set on the context.
+	val := r.Context().Value("msgInstallFunc")
+	if val != nil {
+		// Assert that the context value is of the expected type.
+		fn, ok := val.(MsgInstallFunctionFunc)
+		if !ok {
+			// Should never happen.
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		msgInstallFunc = fn
 	}
 
-	// create a channel to wait for the response
-	responseCh := make(chan models.ResponseInstall)
-	go func() {
-		// call the function
-		ctx := context.WithValue(r.Context(), "installResponseChannel", responseCh)
-		if msgInstallFunc != nil {
-			msgInstallFunc(ctx, request)
-		}
-		response := models.ResponseInstall{
-			Code: enums.ResponseCodeOk,
-		}
-		// send the response to the channel
-		responseCh <- response
-	}()
+	err = msgInstallFunc(r.Context(), request)
+	if err != nil {
 
-	// wait for the response from the channel
-	response := <-responseCh
-	json.NewEncoder(w).Encode(response)
+		log.WithError(err).
+			WithField("uri", request.Uri).
+			WithField("cid", request.Cid).
+			Error("failed to install function")
+
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	response := models.ResponseInstall{
+		Code: enums.ResponseCodeOk,
+	}
+
+	// Write response.
+	err = json.NewEncoder(w).Encode(response)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 }
 
 func handleRootRequest(w http.ResponseWriter, r *http.Request) {

--- a/src/restapi/params.go
+++ b/src/restapi/params.go
@@ -1,0 +1,9 @@
+package restapi
+
+import (
+	"time"
+)
+
+const (
+	functionInstallTimeout = 10 * time.Second
+)


### PR DESCRIPTION
This PR tweaks the server handling of the _function install_ execution flow. If the request succeeds or fails within the specified timeout (10 seconds), the information will be relayed back to the user; otherwise, the request is cancelled and a `408 Request Timeout` status will be sent.

Other than this functionality change, functions relating to _function_ install are slightly refactored, while aiming to retain backwards compatibility. Tests were updated/added, increasing the code coverage slightly:

```
src/controller - 14.7% => 22.5%
src/restapi - 59.2% => 62.3%
```

Tests in `src/restapi` retain similar code style to existing tests in the same file.

NOTE: Request timeout should be a configurable parameter in the future.