### PR TITLE
Creating a `host` package to handle `libp2p` related functionality

### DIFF
--- a/host/config.go
+++ b/host/config.go
@@ -1,0 +1,56 @@
+package host
+
+import (
+	"github.com/multiformats/go-multiaddr"
+)
+
+// defaultConfig used to create Host.
+var defaultConfig = Config{
+	PrivateKey:          "",
+	ConnectionThreshold: 20,
+	DialBackPeersLimit:  100,
+}
+
+// Config represents the Host configuration.
+type Config struct {
+	PrivateKey          string
+	ConnectionThreshold uint
+	BootNodes           []multiaddr.Multiaddr
+	DialBackPeers       []multiaddr.Multiaddr
+	DialBackPeersLimit  uint
+}
+
+// WithPrivateKey specifies the private key for the Host.
+func WithPrivateKey(filepath string) func(*Config) {
+	return func(cfg *Config) {
+		cfg.PrivateKey = filepath
+	}
+}
+
+// WithConnectionThreshold specifies how many connections should the host wait for on peer discovery.
+func WithConnectionThreshold(n uint) func(*Config) {
+	return func(cfg *Config) {
+		cfg.ConnectionThreshold = n
+	}
+}
+
+// WithBootNodes specifies boot nodes that the host initially tries to connect to.
+func WithBootNodes(nodes []multiaddr.Multiaddr) func(*Config) {
+	return func(cfg *Config) {
+		cfg.BootNodes = nodes
+	}
+}
+
+// WithDialBackPeers specifies dial-back peers that the host initially tries to connect to.
+func WithDialBackPeers(peers []multiaddr.Multiaddr) func(*Config) {
+	return func(cfg *Config) {
+		cfg.DialBackPeers = peers
+	}
+}
+
+// WithDialBackPeersLimit specifies the maximum number of dial-back peers to use.
+func WithDialBackPeersLimit(n uint) func(*Config) {
+	return func(cfg *Config) {
+		cfg.DialBackPeersLimit = n
+	}
+}

--- a/host/dht.go
+++ b/host/dht.go
@@ -1,0 +1,154 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
+	"github.com/libp2p/go-libp2p/p2p/discovery/util"
+)
+
+func (h *Host) DiscoverPeers(ctx context.Context, topic string) error {
+
+	// Initialize DHT.
+	dht, err := h.initDHT(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize DHT: %w", err)
+	}
+
+	discovery := routing.NewRoutingDiscovery(dht)
+	util.Advertise(ctx, discovery, topic)
+
+	h.log.Debug().Msg("host started peer discovery")
+
+	connected := uint(0)
+findPeers:
+	for {
+		peers, err := discovery.FindPeers(ctx, topic)
+		if err != nil {
+			return fmt.Errorf("could not find peers: %w", err)
+		}
+
+		for peer := range peers {
+			// Skip self.
+			if peer.ID == h.ID() {
+				continue
+			}
+
+			err = h.Connect(ctx, peer)
+			if err != nil {
+				h.log.Debug().
+					Err(err).
+					Str("peer", peer.String()).
+					Msg("could not connect to peer")
+				continue
+			}
+
+			h.log.Info().Str("peer", peer.String()).Msg("connected to peer")
+
+			connected++
+
+			// Stop when we have reached connection threshold.
+			if connected >= h.cfg.ConnectionThreshold {
+				break findPeers
+			}
+		}
+	}
+
+	h.log.Info().Msg("peer discovery complete")
+	return nil
+}
+
+func (h *Host) initDHT(ctx context.Context) (*dht.IpfsDHT, error) {
+
+	// Start a DHT for use in peer discovery. Set the DHT to server mode.
+	kademliaDHT, err := dht.New(ctx, h.Host, dht.Mode(dht.ModeServer))
+	if err != nil {
+		return nil, fmt.Errorf("could not create DHT: %w", err)
+	}
+
+	// Bootstrap the DHT.
+	err = kademliaDHT.Bootstrap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not bootstrap the DHT: %w", err)
+	}
+
+	bootNodes := h.cfg.BootNodes
+	peers := h.cfg.DialBackPeers
+
+	// Add the dial-back peers to the list of bootstrap nodes if they do not already exist.
+	// TODO: Limit to workers.
+
+	// We may want to limit the number of dial back peers we use.
+	added := uint(0)
+	addLimit := h.cfg.DialBackPeersLimit
+
+	for _, peer := range peers {
+		peer := peer
+
+		// If the limit of dial-back peers is set and we've reached it - stop now.
+		if addLimit != 0 && added >= addLimit {
+			h.log.Info().Uint("limit", addLimit).Msg("reached limit for dial-back peers")
+			break
+		}
+
+		addr := peer.String()
+		addr = strings.Replace(addr, "127.0.0.1", "0.0.0.0", 1)
+
+		// Check if the peer is already among the boot nodes.
+		exists := false
+		for _, bootNode := range bootNodes {
+			if bootNode.String() == addr {
+				exists = true
+				break
+			}
+		}
+
+		// If the peer is not among the boot nodes - add it now.
+		if !exists {
+			bootNodes = append(bootNodes, peer)
+			added++
+		}
+	}
+
+	// Connect to the bootstrap nodes.
+	var wg sync.WaitGroup
+	for _, bootNode := range bootNodes {
+
+		addrInfo, err := peer.AddrInfoFromP2pAddr(bootNode)
+		if err != nil {
+			h.log.Warn().
+				Err(err).
+				Str("address", bootNode.String()).
+				Msg("could not get addrinfo for boot node - skipping")
+			continue
+		}
+
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			peerAddr := addrInfo
+
+			err := h.Host.Connect(ctx, *peerAddr)
+			if err != nil {
+				if err.Error() != errNoGoodAddresses {
+					h.log.Error().
+						Err(err).
+						Str("addrinfo", peerAddr.String()).
+						Msg("could not connect to bootstrap node")
+				}
+			}
+		}()
+	}
+
+	// Wait until we know the outcome of all connection attempts.
+	wg.Wait()
+
+	return kademliaDHT, nil
+}

--- a/host/host.go
+++ b/host/host.go
@@ -1,0 +1,93 @@
+package host
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/host"
+)
+
+// Host represents a new libp2p host.
+type Host struct {
+	log       zerolog.Logger
+	host.Host // TODO: Once the use cases cristalize - reconsider embedding vs private field
+
+	cfg Config
+}
+
+// New creates a new Host.
+func New(log zerolog.Logger, address string, port uint, options ...func(*Config)) (*Host, error) {
+
+	cfg := defaultConfig
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	hostAddress := fmt.Sprintf("/ip4/%v/tcp/%v", address, port)
+	opts := []libp2p.Option{
+		libp2p.ListenAddrStrings(hostAddress),
+		libp2p.DefaultTransports,
+		libp2p.DefaultMuxers,
+		libp2p.DefaultSecurity,
+		libp2p.NATPortMap(),
+	}
+
+	// Read private key, if provided.
+	if cfg.PrivateKey != "" {
+		key, err := readPrivateKey(cfg.PrivateKey)
+		if err != nil {
+			return nil, fmt.Errorf("could not read private key: %w", err)
+		}
+
+		opts = append(opts, libp2p.Identity(key))
+	}
+
+	// Create libp2p host.
+	h, err := libp2p.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("could not create libp2p host: %w", err)
+	}
+
+	host := Host{
+		log: log,
+		cfg: cfg,
+	}
+	host.Host = h
+
+	return &host, nil
+}
+
+// Addresses returns the list of p2p addresses of the host.
+func (h *Host) Addresses() []string {
+
+	addrs := h.Addrs()
+	out := make([]string, 0, len(addrs))
+
+	hostID := h.ID()
+
+	for _, addr := range addrs {
+		addr := fmt.Sprintf("%s/p2p/%s", addr.String(), hostID.String())
+		out = append(out, addr)
+	}
+
+	return out
+}
+
+func readPrivateKey(filepath string) (crypto.PrivKey, error) {
+
+	payload, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read file: %w", err)
+	}
+
+	key, err := crypto.UnmarshalPrivateKey(payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal private key: %w", err)
+	}
+
+	return key, nil
+}

--- a/host/params.go
+++ b/host/params.go
@@ -1,0 +1,6 @@
+package host
+
+const (
+	// Sentinel error for DHT.
+	errNoGoodAddresses = "no good addresses"
+)

--- a/host/publish.go
+++ b/host/publish.go
@@ -1,0 +1,20 @@
+package host
+
+import (
+	"context"
+	"fmt"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+// Publish will publish the message on the provided gossipsub topic.
+func (h *Host) Publish(ctx context.Context, topic *pubsub.Topic, payload []byte) error {
+
+	// Publish the message.
+	err := topic.Publish(ctx, payload)
+	if err != nil {
+		return fmt.Errorf("could not publish message: %w", err)
+	}
+
+	return nil
+}

--- a/host/send.go
+++ b/host/send.go
@@ -1,0 +1,28 @@
+package host
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+)
+
+// SendMessage sends a message directly to the specified peer.
+func (h *Host) SendMessage(ctx context.Context, to peer.ID, payload []byte) error {
+
+	stream, err := h.Host.NewStream(ctx, to, blockless.ProtocolID)
+	if err != nil {
+		return fmt.Errorf("could not create stream: %w", err)
+	}
+	defer stream.Close()
+
+	_, err = stream.Write(payload)
+	if err != nil {
+		stream.Reset()
+		return fmt.Errorf("could not write payload: %w", err)
+	}
+
+	return nil
+}

--- a/host/subscribe.go
+++ b/host/subscribe.go
@@ -1,0 +1,32 @@
+package host
+
+import (
+	"context"
+	"fmt"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+// Subscribe will have the host start listening to a specified gossipsub topic.
+func (h *Host) Subscribe(ctx context.Context, topic string) (*pubsub.Topic, *pubsub.Subscription, error) {
+
+	// Get a new PubSub object with the default router.
+	pubsub, err := pubsub.NewGossipSub(ctx, h)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not create new gossipsub: %w", err)
+	}
+
+	// Join the specified topic.
+	th, err := pubsub.Join(topic)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not join topic: %w", err)
+	}
+
+	// Subscribe to the topic.
+	subscription, err := th.Subscribe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not subscribe to topic: %w", err)
+	}
+
+	return th, subscription, nil
+}


### PR DESCRIPTION
This PR introduces a `host` package that can be used by the node to manage all of the `libp2p` related actions. This package/type will obsolete a few other existing packages, such as `dht`, `host` and some functionality dispersed between a few other packages.

(Obsoleted packages are not removed as part of this PR.)

On construction, there are a few configuration options that can be set.

## Configuration Options

### Private Key Path

Path to the private key found on the filesystem, used to determine host/node identity.

### Connection Threshold

On peer discovery, try to find peers until connection with this many peers are established. Default - 20.

### Boot Nodes

Known nodes/peers, specified via CLI flags. These are the nodes we will try to connect with on boot.

### Dial Back Peers

Similar to boot nodes, but are peers that the node had been connected to in the past.

### Dial Back Peers Limit

List of dial back peers can be quite large, so we provide the option to put a cap on how many we want to use. Default is 100.

## Example

```go
	// Create libp2p host.
	host, err := host.New(log, cfg.Host.Address, cfg.Host.Port,
		host.WithPrivateKey(cfg.Host.PrivateKey),
		host.WithBootNodes(bootNodeAddrs),
		host.WithDialBackPeers(peerAddrs),
	)
```