### PR TITLE
Add node functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+cmd/node/node
+cmd/keygen/keygen
+
 dist/
 runtime/
 *.env

--- a/cmd/keygen/main.go
+++ b/cmd/keygen/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/pflag"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+const (
+	// Names used for created files.
+	privKeyName  = "priv.bin"
+	pubKeyName   = "pub.bin"
+	identityName = "identity"
+)
+
+const (
+	// Permissions used for created files.
+	privKeyPermissions = 0600
+	pubKeyPermissions  = 0644
+)
+
+func main() {
+
+	var (
+		flagOutputDir string
+	)
+
+	pflag.StringVarP(&flagOutputDir, "output", "o", ".", "directory where keys should be stored")
+
+	pflag.Parse()
+
+	// Create output directory, if it doesn't exist.
+	err := os.MkdirAll(flagOutputDir, os.ModePerm)
+	if err != nil {
+		log.Fatalf("could not create output directory: %s", err)
+	}
+
+	// Generate key pair.
+	priv, pub, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
+	if err != nil {
+		log.Fatalf("could not generate key pair: %s", err)
+	}
+
+	// Encode keys and extract peer ID from key.
+	privPayload, err := crypto.MarshalPrivateKey(priv)
+	if err != nil {
+		log.Fatalf("could not marshal private key: %s", err)
+	}
+
+	pubPayload, err := crypto.MarshalPublicKey(pub)
+	if err != nil {
+		log.Fatalf("could not marshal public key: %s", err)
+	}
+
+	identity, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		log.Fatalf("failed to get peer identity from public key: %s", err)
+	}
+
+	// Write keys and identity to files.
+
+	pubKeyFile := filepath.Join(flagOutputDir, pubKeyName)
+	err = os.WriteFile(pubKeyFile, pubPayload, pubKeyPermissions)
+	if err != nil {
+		log.Fatalf("could not write private key to file: %s", err)
+	}
+
+	idFile := filepath.Join(flagOutputDir, identityName)
+	err = os.WriteFile(idFile, []byte(identity), pubKeyPermissions)
+	if err != nil {
+		log.Fatalf("could not write private key to file: %s", err)
+	}
+
+	privKeyFile := filepath.Join(flagOutputDir, privKeyName)
+	err = os.WriteFile(privKeyFile, privPayload, privKeyPermissions)
+	if err != nil {
+		log.Fatalf("could not write private key to file: %s", err)
+	}
+
+	fmt.Printf("generated private key: %s\n", privKeyFile)
+	fmt.Printf("generated public key: %s\n", pubKeyFile)
+	fmt.Printf("generated identity file: %s\n", idFile)
+}

--- a/cmd/node/address.go
+++ b/cmd/node/address.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/multiformats/go-multiaddr"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+)
+
+// getPeerAddresses returns the list of the multiaddreses for the peer list.
+func getPeerAddresses(peers []blockless.Peer) ([]multiaddr.Multiaddr, error) {
+
+	var addrs []multiaddr.Multiaddr
+
+	for _, peer := range peers {
+
+		addr, err := multiaddr.NewMultiaddr(peer.MultiAddr)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse multiaddress (addr: %s): %w", peer.MultiAddr, err)
+		}
+
+		addrs = append(addrs, addr)
+	}
+
+	return addrs, nil
+}
+
+// parse list of strings with multiaddresses
+func getBootNodeAddresses(addrs []string) ([]multiaddr.Multiaddr, error) {
+
+	var out []multiaddr.Multiaddr
+	for _, addr := range addrs {
+
+		addr, err := multiaddr.NewMultiaddr(addr)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse multiaddress (addr: %s): %w", addr, err)
+		}
+
+		out = append(out, addr)
+	}
+
+	return out, nil
+}

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/blocklessnetworking/b7s/config"
+)
+
+// Default values.
+const (
+	defaultPort    = 0
+	defaultAddress = "0.0.0.0"
+	defaultDB      = "db"
+
+	defaultRole = "worker"
+)
+
+func parseFlags() *config.Config {
+
+	var cfg config.Config
+
+	pflag.StringVarP(&cfg.Log.Level, "log-level", "l", "info", "log level to use")
+	pflag.StringVarP(&cfg.DatabasePath, "db", "d", defaultDB, "path to the database used for persisting node data")
+
+	// Node configuration.
+	pflag.StringVarP(&cfg.Role, "role", "r", defaultRole, "role this note will have in the Blockless protocol (head or worker)")
+	pflag.StringVarP(&cfg.Host.Address, "address", "a", defaultAddress, "address that the libp2p host will use")
+	pflag.UintVarP(&cfg.Host.Port, "port", "p", defaultPort, "port that the libp2p host will use")
+	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the libp2p host will use")
+	pflag.StringVar(&cfg.API, "rest-api", "", "address where the head node REST API will listen on")
+	pflag.StringSliceVar(&cfg.BootNodes, "boot-nodes", nil, "list of addresses that this node will connect to on startup, in multiaddr format")
+
+	pflag.StringVar(&cfg.Workspace, "workspace", "./workspace", "directory that the node can use for file storage")
+	pflag.StringVar(&cfg.Runtime, "runtime", "", "runtime address (used by the worker node)")
+
+	pflag.Parse()
+
+	return &cfg
+}

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+	"github.com/ziflex/lecho/v3"
+
+	"github.com/blocklessnetworking/b7s/api"
+	"github.com/blocklessnetworking/b7s/executor"
+	"github.com/blocklessnetworking/b7s/function"
+	"github.com/blocklessnetworking/b7s/host"
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/node"
+	"github.com/blocklessnetworking/b7s/peerstore"
+	"github.com/blocklessnetworking/b7s/store"
+)
+
+const (
+	success = 0
+	failure = 1
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+
+	// Signal catching for clean shutdown.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+
+	// Initialize logging.
+	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.DebugLevel)
+
+	// Parse CLI flags and validate that the configuration is valid.
+	cfg := parseFlags()
+
+	// Set log level.
+	level, err := zerolog.ParseLevel(cfg.Log.Level)
+	if err != nil {
+		log.Error().Err(err).Str("level", cfg.Log.Level).Msg("could not parse log level")
+		return failure
+	}
+	log = log.Level(level)
+
+	// Determine node role.
+	role, err := parseNodeRole(cfg.Role)
+	if err != nil {
+		log.Error().Err(err).Str("role", cfg.Role).Msg("invalid node role specified")
+		return failure
+	}
+
+	// Open the pebble database.
+	pdb, err := pebble.Open(cfg.DatabasePath, &pebble.Options{})
+	if err != nil {
+		log.Error().Err(err).Str("db", cfg.DatabasePath).Msg("could not open pebble database")
+		return failure
+	}
+	defer pdb.Close()
+
+	// Create a new store.
+	store := store.New(pdb)
+
+	peerstore := peerstore.New(store)
+
+	// Get the list of dial back peers.
+	peers, err := peerstore.Peers()
+	if err != nil {
+		log.Error().Err(err).Msg("could not get list of dial-back peers")
+		return failure
+	}
+	peerAddrs, err := getPeerAddresses(peers)
+	if err != nil {
+		log.Error().Err(err).Msg("could not get peer addresses")
+		return failure
+	}
+
+	// Get the list of boot nodes addresses.
+	bootNodeAddrs, err := getBootNodeAddresses(cfg.BootNodes)
+	if err != nil {
+		log.Error().Err(err).Msg("could not get boot node addresses")
+		return failure
+	}
+
+	// Create libp2p host.
+	host, err := host.New(log, cfg.Host.Address, cfg.Host.Port,
+		host.WithPrivateKey(cfg.Host.PrivateKey),
+		host.WithBootNodes(bootNodeAddrs),
+		host.WithDialBackPeers(peerAddrs),
+	)
+	if err != nil {
+		log.Error().Err(err).Str("key", cfg.Host.PrivateKey).Msg("could not create host")
+		return failure
+	}
+
+	log.Info().
+		Str("id", host.ID().String()).
+		Strs("addresses", host.Addresses()).
+		Int("boot_nodes", len(bootNodeAddrs)).
+		Int("dial_back_peers", len(peerAddrs)).
+		Msg("created host")
+
+	// Set node options.
+	opts := []node.Option{
+		node.WithRole(role),
+	}
+
+	// If this is a worker node, initialize an executor.
+	if role == blockless.WorkerNode {
+
+		// Crete an executor.
+		executor, err := executor.New(log, cfg.Workspace, cfg.Runtime)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("workspace", cfg.Workspace).
+				Str("runtime", cfg.Runtime).
+				Msg("could not create an executor")
+			return failure
+		}
+
+		opts = append(opts, node.WithExecutor(executor))
+	}
+
+	// Create function handler.
+	functionHandler := function.New(log, store, cfg.Workspace)
+
+	// Instantiate node.
+	node, err := node.New(log, host, store, peerstore, functionHandler, opts...)
+	if err != nil {
+		log.Error().Err(err).Msg("could not create node")
+		return failure
+	}
+
+	// Create the main context.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	failed := make(chan struct{})
+
+	// Start node main loop in a separate goroutine.
+	go func() {
+
+		log.Info().
+			Str("role", role.String()).
+			Msg("Blockless Node starting")
+
+		err := node.Run(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("Blockless Node failed")
+			close(failed)
+		} else {
+			close(done)
+		}
+
+		log.Info().Msg("Blockless Node stopped")
+	}()
+
+	// If we're a head node - start the REST API.
+	if role == blockless.HeadNode {
+
+		if cfg.API == "" {
+			log.Error().Err(err).Msg("REST API address is required")
+			return failure
+		}
+
+		// Create echo server and iniialize logging.
+		server := echo.New()
+		server.HideBanner = true
+		server.HidePort = true
+
+		elog := lecho.From(log)
+		server.Logger = elog
+		server.Use(lecho.Middleware(lecho.Config{Logger: elog}))
+
+		// Create an API handler.
+		api := api.New(log, node)
+
+		// Set endpoint handlers.
+		server.POST("/api/v1/functions/execute", api.Execute)
+		server.GET("/api/v1/functions/:id/install", api.Install)
+		server.GET("/api/v1/functions/requests/:id/result", api.ExecutionResult)
+
+		// Start API in a separate goroutine.
+		go func() {
+
+			log.Info().Msg("Node API starting")
+			err := server.Start(cfg.API)
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Warn().Err(err).Msg("Node API failed")
+				close(failed)
+			} else {
+				close(done)
+			}
+
+			log.Info().Msg("Node API stopped")
+		}()
+	}
+
+	select {
+	case <-sig:
+		log.Info().Msg("Blockless Node stopping")
+	case <-done:
+		log.Info().Msg("Blockless Node done")
+	case <-failed:
+		log.Info().Msg("Blockless Node aborted")
+		return failure
+	}
+
+	// If we receive a second interrupt signal, exit immediately.
+	go func() {
+		<-sig
+		log.Warn().Msg("forcing exit")
+		os.Exit(1)
+	}()
+
+	return success
+}

--- a/cmd/node/parse.go
+++ b/cmd/node/parse.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+)
+
+func parseNodeRole(role string) (blockless.NodeRole, error) {
+
+	switch role {
+
+	case blockless.HeadNodeLabel:
+		return blockless.HeadNode, nil
+
+	case blockless.WorkerNodeLabel:
+		return blockless.WorkerNode, nil
+
+	default:
+		return 0, errors.New("invalid node role")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Load will load the config file from the given location.
+func Load(file string) (*Config, error) {
+
+	// Read config file.
+	payload, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("could not read file: %w", err)
+	}
+
+	// Unmarshal file.
+	var config Config
+	err = yaml.Unmarshal(payload, &config)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal file: %w", err)
+	}
+
+	return &config, nil
+}

--- a/config/model.go
+++ b/config/model.go
@@ -1,0 +1,27 @@
+package config
+
+// Config describes the Blockless configuration options.
+type Config struct {
+	Log          Log
+	DatabasePath string
+	Role         string
+	BootNodes    []string
+
+	Host    Host
+	API     string
+	Runtime string
+
+	Workspace string
+}
+
+// Host describes the libp2p host that the node will use.
+type Host struct {
+	Port       uint
+	Address    string
+	PrivateKey string
+}
+
+// Log describes the logging configuration.
+type Log struct {
+	Level string
+}

--- a/models/api/request/request.go
+++ b/models/api/request/request.go
@@ -1,0 +1,14 @@
+package request
+
+import (
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+// Execute describes the payload for the REST API request for function execution.
+type Execute execute.Request
+
+// InstallFunction describes the payload for the REST API request for function install.
+type InstallFunction struct {
+	CID string `query:"cid"`
+	URI string `query:"uri"`
+}

--- a/models/api/response/response.go
+++ b/models/api/response/response.go
@@ -1,0 +1,13 @@
+package response
+
+import (
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+// Execute describes the REST API response for function execution.
+type Execute execute.Result
+
+// InstallFunction describes the REST API response for the function install.
+type InstallFunction struct {
+	Code string `json:"code"`
+}

--- a/models/blockless/errors.go
+++ b/models/blockless/errors.go
@@ -1,0 +1,10 @@
+package blockless
+
+import (
+	"errors"
+)
+
+// Sentinel errors.
+var (
+	ErrNotFound = errors.New("not found")
+)

--- a/models/blockless/function.go
+++ b/models/blockless/function.go
@@ -1,0 +1,56 @@
+package blockless
+
+// FunctionManifest describes some important configuration options for a Blockless function.
+type FunctionManifest struct {
+	ID          string        `json:"id,omitempty"`
+	Name        string        `json:"name,omitempty"`
+	Description string        `json:"description,omitempty"`
+	Function    Function      `json:"function,omitempty"`
+	Deployment  Deployment    `json:"deployment,omitempty"`
+	Runtime     Runtime       `json:"runtime,omitempty"`
+	Cached      bool          `json:"cached,omitempty"`
+	Hooks       []interface{} `json:"hooks,omitempty"`
+	FSRootPath  string        `json:"fs_root_path,omitempty"`
+	Entry       string        `json:"entry,omitempty"`
+	ContentType string        `json:"contentType,omitempty"`
+	Permissions []string      `json:"permissions,omitempty"`
+}
+
+// Runtime is here to support legacy manifests.
+type Runtime struct {
+	Checksum string `json:"checksum,omitempty"`
+	URL      string `json:"url,omitempty"`
+}
+
+// Function represents a Blockless function that can be executed.
+type Function struct {
+	ID         string   `json:"id,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	Version    string   `json:"version,omitempty"`
+	Runtime    string   `json:"runtime,omitempty"`
+	Extensions []string `json:"extensions,omitempty"`
+}
+
+type Deployment struct {
+	CID         string    `json:"cid,omitempty"`
+	Checksum    string    `json:"checksum,omitempty"`
+	URI         string    `json:"uri,omitempty"`
+	Methods     []Methods `json:"methods,omitempty"`
+	Aggregation string    `json:"aggregation,omitempty"`
+	Nodes       int       `json:"nodes,omitempty"`
+	File        string    `json:"file,omitempty"`
+}
+
+type Methods struct {
+	Name       string      `json:"name,omitempty"`
+	Entry      string      `json:"entry,omitempty"`
+	Arguments  []Parameter `json:"arguments,omitempty"`
+	EnvVars    []Parameter `json:"envvars,omitempty"`
+	ResultType string      `json:"result_type,omitempty"`
+}
+
+// Parameter represents a generic name-value pair.
+type Parameter struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}

--- a/models/blockless/message.go
+++ b/models/blockless/message.go
@@ -1,0 +1,29 @@
+package blockless
+
+// Message types in the Blockless protocol.
+const (
+	MessageHealthCheck             = "MsgHealthCheck"
+	MessageExecute                 = "MsgExecute"
+	MessageExecuteResult           = "MsgExecuteResult"
+	MessageExecuteError            = "MsgExecuteError"
+	MessageExecuteTimeout          = "MsgExecuteTimeout"
+	MessageExecuteUnknown          = "MsgExecuteUnknown"
+	MessageExecuteInvalid          = "MsgExecuteInvalid"
+	MessageExecuteNotFound         = "MsgExecuteNotFound"
+	MessageExecuteNotSupported     = "MsgExecuteNotSupported"
+	MessageExecuteNotImplemented   = "MsgExecuteNotImplemented"
+	MessageExecuteNotAuthorized    = "MsgExecuteNotAuthorized"
+	MessageExecuteNotPermitted     = "MsgExecuteNotPermitted"
+	MessageExecuteNotAvailable     = "MsgExecuteNotAvailable"
+	MessageExecuteNotReady         = "MsgExecuteNotReady"
+	MessageExecuteNotConnected     = "MsgExecuteNotConnected"
+	MessageExecuteNotInitialized   = "MsgExecuteNotInitialized"
+	MessageExecuteNotConfigured    = "MsgExecuteNotConfigured"
+	MessageExecuteNotInstalled     = "MsgExecuteNotInstalled"
+	MessageExecuteNotUpgraded      = "MsgExecuteNotUpgraded"
+	MessageRollCall                = "MsgRollCall"
+	MessageRollCallResponse        = "MsgRollCallResponse"
+	MessageExecuteResponse         = "MsgExecuteResponse"
+	MessageInstallFunction         = "MsgInstallFunction"
+	MessageInstallFunctionResponse = "MsgInstallFunctionResponse"
+)

--- a/models/blockless/peer.go
+++ b/models/blockless/peer.go
@@ -1,0 +1,13 @@
+package blockless
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Peer identifies another node in the Blockless network.
+type Peer struct {
+	Type      string        `json:"type,omitempty"`
+	ID        peer.ID       `json:"id,omitempty"`
+	MultiAddr string        `json:"multiaddress,omitempty"`
+	AddrInfo  peer.AddrInfo `json:"addrinfo,omitempty"`
+}

--- a/models/blockless/protocol.go
+++ b/models/blockless/protocol.go
@@ -1,0 +1,9 @@
+package blockless
+
+import (
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+const (
+	ProtocolID protocol.ID = "/b7s/work/1.0.0"
+)

--- a/models/blockless/role.go
+++ b/models/blockless/role.go
@@ -1,0 +1,33 @@
+package blockless
+
+// TODO: Reconsider the package name - typically I'd use the name of the project - `b7s`.
+// Package `blockless` might be too wide.
+
+// NodeRole is a representation of the node's role.
+type NodeRole uint8
+
+// The following are all possible node roles.
+const (
+	HeadNode NodeRole = iota + 1
+	WorkerNode
+)
+
+// The following are labels for the node roles, used when parsing the node role as a string.
+const (
+	HeadNodeLabel   = "head"
+	WorkerNodeLabel = "worker"
+)
+
+// String returns the string representation of the node role.
+func (n NodeRole) String() string {
+
+	switch n {
+
+	case HeadNode:
+		return HeadNodeLabel
+	case WorkerNode:
+		return WorkerNodeLabel
+	default:
+		return "invalid"
+	}
+}

--- a/models/execute/request.go
+++ b/models/execute/request.go
@@ -1,0 +1,36 @@
+package execute
+
+// Request describes an execution request.
+type Request struct {
+	FunctionID string      `json:"function_id"`
+	Method     string      `json:"method"`
+	Parameters []Parameter `json:"parameters"`
+	Config     Config      `json:"config"`
+}
+
+// Parameter represents an execution parameter, modeled as a key-value pair.
+type Parameter struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Config represents the configurable options for an execution request.
+type Config struct {
+	Environment       []EnvVar          `json:"env_vars"`
+	NodeCount         int               `json:"number_of_nodes"`
+	ResultAggregation ResultAggregation `json:"result_aggregation"`
+	Stdin             *string           `json:"stdin"`
+	Permissions       []string          `json:"permissions"`
+}
+
+// EnvVar represents the name and value of the environment variables set for the execution.
+type EnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type ResultAggregation struct {
+	Enable     bool        `json:"enable"`
+	Type       string      `json:"type"`
+	Parameters []Parameter `json:"parameters"`
+}

--- a/models/execute/response.go
+++ b/models/execute/response.go
@@ -1,0 +1,8 @@
+package execute
+
+// Result describes an execution result.
+type Result struct {
+	Code      string `json:"code"`
+	Result    string `json:"result"`
+	RequestID string `json:"request_id"`
+}

--- a/models/request/execute.go
+++ b/models/request/execute.go
@@ -1,0 +1,18 @@
+package request
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+// Execute describes the `MessageExecute` request payload.
+type Execute struct {
+	Type       string              `json:"type,omitempty"`
+	From       peer.ID             `json:"from,omitempty"`
+	Code       string              `json:"code,omitempty"`
+	FunctionID string              `json:"function_id,omitempty"`
+	Method     string              `json:"method,omitempty"`
+	Parameters []execute.Parameter `json:"parameters,omitempty"`
+	Config     execute.Config      `json:"config,omitempty"`
+}

--- a/models/request/install_function.go
+++ b/models/request/install_function.go
@@ -1,0 +1,13 @@
+package request
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// InstallFunction describes the `MessageInstallFunction` request payload.
+type InstallFunction struct {
+	Type        string  `json:"type,omitempty"`
+	From        peer.ID `json:"from,omitempty"`
+	ManifestURL string  `json:"manifest_url,omitempty"`
+	CID         string  `json:"cid,omitempty"`
+}

--- a/models/request/roll_call.go
+++ b/models/request/roll_call.go
@@ -1,0 +1,13 @@
+package request
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// RollCall describes the `MessageRollCall` message payload.
+type RollCall struct {
+	From       peer.ID `json:"from,omitempty"`
+	Type       string  `json:"type,omitempty"`
+	FunctionID string  `json:"function_id,omitempty"`
+	RequestID  string  `json:"request_id,omitempty"`
+}

--- a/models/response/code.go
+++ b/models/response/code.go
@@ -1,0 +1,17 @@
+package response
+
+// Response codes.
+const (
+	CodeOK             = "200"
+	CodeAccepted       = "202"
+	CodeError          = "500"
+	CodeTimeout        = "408"
+	CodeUnknown        = "520"
+	CodeInvalid        = "400"
+	CodeNotFound       = "404"
+	CodeNotSupported   = "501"
+	CodeNotImplemented = "501"
+	CodeNotAuthorized  = "401"
+	CodeNotPermitted   = "403"
+	CodeNotAvailable   = "503"
+)

--- a/models/response/execute.go
+++ b/models/response/execute.go
@@ -1,0 +1,14 @@
+package response
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Execute describes the `MessageExecuteResponse` message payload.
+type Execute struct {
+	Type      string  `json:"type,omitempty"`
+	RequestID string  `json:"request_id,omitempty"`
+	From      peer.ID `json:"from,omitempty"`
+	Code      string  `json:"code,omitempty"`
+	Result    string  `json:"result,omitempty"`
+}

--- a/models/response/health.go
+++ b/models/response/health.go
@@ -1,0 +1,12 @@
+package response
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Health describes the message sent as a health ping.
+type Health struct {
+	Type string  `json:"type,omitempty"`
+	From peer.ID `json:"from,omitempty"`
+	Code string  `json:"code,omitempty"`
+}

--- a/models/response/install_function.go
+++ b/models/response/install_function.go
@@ -1,0 +1,13 @@
+package response
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// InstallFunction describes the response to the `MessageInstallFunction` message.
+type InstallFunction struct {
+	Type    string  `json:"type,omitempty"`
+	From    peer.ID `json:"from,omitempty"`
+	Code    string  `json:"code,omitempty"`
+	Message string  `json:"message,omitempty"`
+}

--- a/models/response/roll_call.go
+++ b/models/response/roll_call.go
@@ -1,0 +1,15 @@
+package response
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// RollCall describes the `MessageRollCall` response payload.
+type RollCall struct {
+	Type       string  `json:"type,omitempty"`
+	From       peer.ID `json:"from,omitempty"`
+	Code       string  `json:"code,omitempty"`
+	Role       string  `json:"role,omitempty"`
+	FunctionID string  `json:"function_id,omitempty"`
+	RequestID  string  `json:"request_id,omitempty"`
+}

--- a/node/config.go
+++ b/node/config.go
@@ -1,0 +1,42 @@
+package node
+
+import (
+	"github.com/blocklessnetworking/b7s/models/blockless"
+)
+
+// Option can be used to set Node configuration options.
+type Option func(*Config)
+
+// DefaultConfig represents the default settings for the node.
+var DefaultConfig = Config{
+	Role:  blockless.WorkerNode,
+	Topic: DefaultTopic,
+}
+
+// Config represents the Node configuration.
+type Config struct {
+	Role    blockless.NodeRole // Node role.
+	Topic   string             // Topic to subscribe to.
+	Execute Executor           // Executor to use for running functions.
+}
+
+// WithRole specifies the role for the node.
+func WithRole(role blockless.NodeRole) Option {
+	return func(cfg *Config) {
+		cfg.Role = role
+	}
+}
+
+// WithTopic specifies the p2p topic to which node should subscribe.
+func WithTopic(topic string) Option {
+	return func(cfg *Config) {
+		cfg.Topic = topic
+	}
+}
+
+// WithExecutor specifies the executor to be used for running Blockless functions
+func WithExecutor(execute Executor) Option {
+	return func(cfg *Config) {
+		cfg.Execute = execute
+	}
+}

--- a/node/execute.go
+++ b/node/execute.go
@@ -1,0 +1,263 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetworking/b7s/models/request"
+	"github.com/blocklessnetworking/b7s/models/response"
+)
+
+// executeFunc is a function that handles an execution request. In case of a worker node,
+// the function is executed locally. In case of a head node, a roll call request is issued,
+// and the execution request is relayed to, and retrieved from, a worker node that volunteers.
+// NOTE: By using `execute.Result` here as the type, if this is executed on the head node we are
+// losing the information about `who` is the peer that sent us the result - the `from` field.
+type executeFunc func(context.Context, peer.ID, execute.Request) (execute.Result, error)
+
+func (n *Node) processExecute(ctx context.Context, from peer.ID, payload []byte) error {
+
+	// Unpack the request.
+	var req request.Execute
+	err := json.Unmarshal(payload, &req)
+	if err != nil {
+		return fmt.Errorf("could not unpack the request: %w", err)
+	}
+	req.From = from
+
+	// Create execute request.
+	execReq := execute.Request{
+		FunctionID: req.FunctionID,
+		Method:     req.Method,
+		Parameters: req.Parameters,
+		Config:     req.Config,
+	}
+
+	// Call the appropriate function that executes the request in the appropriate way.
+	// NOTE: In case of an error, we do not return from this function.
+	// Instead, we send the response back to the caller, whatever it may be.
+	var execFunc executeFunc
+	if n.role == blockless.WorkerNode {
+		execFunc = n.workerExecute
+	} else {
+		execFunc = n.headExecute
+	}
+
+	result, err := execFunc(ctx, from, execReq)
+	if err != nil {
+		n.log.Error().
+			Err(err).
+			Str("peer", from.String()).
+			Str("function_id", req.FunctionID).
+			Msg("execution failed")
+	}
+
+	// Cache the execution result.
+	n.excache.Set(result.RequestID, result)
+
+	// Create the execution response from the execution result.
+	res := response.Execute{
+		Type:      blockless.MessageExecuteResponse,
+		RequestID: result.RequestID,
+		Code:      result.Code,
+		Result:    result.Result,
+	}
+
+	// Send the response, whatever it may be (success or failure).
+	err = n.send(ctx, req.From, res)
+	if err != nil {
+		return fmt.Errorf("could not send response: %w", err)
+	}
+
+	return nil
+}
+
+func (n *Node) workerExecute(ctx context.Context, from peer.ID, req execute.Request) (execute.Result, error) {
+
+	// Check if we have function in store.
+	functionInstalled, err := n.isFunctionInstalled(req.FunctionID)
+	if err != nil {
+		res := execute.Result{
+			Code: response.CodeError,
+		}
+		return res, fmt.Errorf("could not lookup function in store: %w", err)
+	}
+
+	if !functionInstalled {
+		res := execute.Result{
+			Code: response.CodeNotFound,
+		}
+
+		return res, nil
+	}
+
+	// Execute the function.
+	res, err := n.execute.Function(req)
+	if err != nil {
+		return res, fmt.Errorf("execution failed: %w", err)
+	}
+
+	return res, nil
+}
+
+func (n *Node) headExecute(ctx context.Context, from peer.ID, req execute.Request) (execute.Result, error) {
+
+	requestID, err := n.issueRollCall(ctx, req.FunctionID)
+	if err != nil {
+
+		res := execute.Result{
+			Code: response.CodeError,
+		}
+
+		return res, fmt.Errorf("could not issue roll call: %w", err)
+	}
+
+	n.log.Info().
+		Str("function_id", req.FunctionID).
+		Str("request_id", requestID).
+		Msg("roll call published")
+
+	// Limit for how long we wait for responses.
+	tctx, cancel := context.WithTimeout(ctx, rollCallTimeout)
+	defer cancel()
+
+	// Peer that reports to roll call first.
+	var reportingPeer peer.ID
+rollCallResponseLoop:
+	for {
+		// Wait for responses from nodes who want to work on the request.
+		select {
+		// Request timed out.
+		case <-tctx.Done():
+
+			n.log.Info().
+				Str("function_id", req.FunctionID).
+				Str("request_id", requestID).
+				Msg("roll call timed out")
+
+			res := execute.Result{
+				Code: response.CodeTimeout,
+			}
+
+			return res, errors.New("roll call timed out")
+
+		case reply := <-n.rollCallResponses[requestID]:
+
+			n.log.Debug().
+				Str("peer", reply.From.String()).
+				Str("function_id", req.FunctionID).
+				Str("request_id", requestID).
+				Msg("peer reported for roll call")
+
+			// Check if this is the reply we want.
+			if reply.Code != response.CodeAccepted ||
+				reply.FunctionID != req.FunctionID ||
+				reply.RequestID != requestID {
+				continue
+			}
+
+			// Check if we are connected to this peer.
+			connections := n.host.Network().ConnsToPeer(reply.From)
+			if len(connections) == 0 {
+				continue
+			}
+
+			reportingPeer = reply.From
+			break rollCallResponseLoop
+		}
+	}
+
+	n.log.Info().
+		Str("peer", reportingPeer.String()).
+		Str("function_id", req.FunctionID).
+		Str("request_id", requestID).
+		Msg("peer reported for roll call")
+
+	// Create a channel where execution response will be received.
+	// We create a bufferred channel so sending of execution result does not block.
+	n.executeResponses[requestID] = make(chan response.Execute, resultBufferSize)
+
+	// Request execution from the peer who reported back first.
+	reqExecute := request.Execute{
+		Type:       blockless.MessageExecute,
+		FunctionID: req.FunctionID,
+		Method:     req.Method,
+		Parameters: req.Parameters,
+		Config:     req.Config,
+	}
+
+	// Send message to reporting peer to execute the function.
+	err = n.send(ctx, reportingPeer, reqExecute)
+	if err != nil {
+
+		res := execute.Result{
+			Code: response.CodeError,
+		}
+
+		return res, fmt.Errorf("could not send execution request to peer (peer: %s, function: %s, request: %s): %w",
+			reportingPeer.String(),
+			req.FunctionID,
+			requestID,
+			err)
+	}
+
+	// TODO: Verify that the response came from the peer that reported for the roll call.
+	resExecute := <-n.executeResponses[requestID]
+
+	n.log.Info().
+		Str("request_id", requestID).
+		Str("peer", resExecute.From.String()).
+		Str("code", resExecute.Code).
+		Msg("received execution response")
+
+	// Return the execution result.
+	result := execute.Result{
+		Code:      resExecute.Code,
+		Result:    resExecute.Result,
+		RequestID: resExecute.RequestID,
+	}
+
+	return result, nil
+}
+
+func (n *Node) processExecuteResponse(ctx context.Context, from peer.ID, payload []byte) error {
+
+	// Unpack the message.
+	var res response.Execute
+	err := json.Unmarshal(payload, &res)
+	if err != nil {
+		return fmt.Errorf("could not not unpack execute response: %w", err)
+	}
+	res.From = from
+
+	// Record execution response.
+	n.recordExecuteResponse(res)
+
+	return nil
+}
+
+func (n *Node) recordExecuteResponse(res response.Execute) {
+	n.executeResponses[res.RequestID] <- res
+}
+
+// isFuncitonInstalled looks up the function in the store by using the functionID/CID as key.
+func (n *Node) isFunctionInstalled(functionID string) (bool, error) {
+
+	_, err := n.function.Get("", functionID, true)
+	if err != nil {
+
+		if errors.Is(err, blockless.ErrNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("could not lookup function in store: %w", err)
+	}
+
+	return true, nil
+}

--- a/node/executor.go
+++ b/node/executor.go
@@ -1,0 +1,9 @@
+package node
+
+import (
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+type Executor interface {
+	Function(execute.Request) (execute.Result, error)
+}

--- a/node/function.go
+++ b/node/function.go
@@ -1,0 +1,12 @@
+package node
+
+import (
+	"github.com/blocklessnetworking/b7s/models/blockless"
+)
+
+// FunctionStore provides retrieval of function manifest.
+type FunctionStore interface {
+	// Get retrieves a function manifest based on the address or CID. `useCached` boolean
+	// determines if function manifest should be refetched or previously cached data can be returned.
+	Get(address string, cid string, useCached bool) (*blockless.FunctionManifest, error)
+}

--- a/node/function_manifest.go
+++ b/node/function_manifest.go
@@ -1,0 +1,21 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+)
+
+// getFunctionManifest retrieves the function manifest for the function with the given ID.
+func (n *Node) getFunctionManifest(id string) (*blockless.FunctionManifest, error) {
+
+	// Try to get function manifest from the store.
+	var manifest blockless.FunctionManifest
+	err := n.store.GetRecord(id, &manifest)
+	if err != nil {
+		// TODO: Check - error not found.
+		return nil, fmt.Errorf("could not retrieve function manifest: %w", err)
+	}
+
+	return &manifest, nil
+}

--- a/node/handlers.go
+++ b/node/handlers.go
@@ -1,0 +1,88 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/request"
+	"github.com/blocklessnetworking/b7s/models/response"
+)
+
+// TODO: peerID of the sender is a good candidate to move on to the context
+
+type HandlerFunc func(context.Context, peer.ID, []byte) error
+
+func (n *Node) processHealthCheck(ctx context.Context, from peer.ID, payload []byte) error {
+	n.log.Debug().
+		Str("from", from.String()).
+		Msg("peer health check received")
+	return nil
+}
+
+func (n *Node) processRollCallResponse(ctx context.Context, from peer.ID, payload []byte) error {
+
+	// Unpack the roll call response.
+	var res response.RollCall
+	err := json.Unmarshal(payload, &res)
+	if err != nil {
+		return fmt.Errorf("could not unpack the roll call response: %w", err)
+	}
+	res.From = from
+
+	// Record the response.
+	n.recordRollCallResponse(res)
+
+	return nil
+}
+
+func (n *Node) recordRollCallResponse(res response.RollCall) {
+	n.rollCallResponses[res.RequestID] <- res
+}
+
+func (n *Node) processInstallFunction(ctx context.Context, from peer.ID, payload []byte) error {
+
+	// Only workers should respond to function install requests.
+	if n.role != blockless.WorkerNode {
+		n.log.Debug().
+			Msg("received function install request, ignoring")
+		return nil
+	}
+
+	// Unpack the request.
+	var req request.InstallFunction
+	err := json.Unmarshal(payload, &req)
+	if err != nil {
+		return fmt.Errorf("could not unpack request: %w", err)
+	}
+	req.From = from
+
+	// Get the function manifest.
+	_, err = n.function.Get(req.ManifestURL, req.CID, true)
+	if err != nil {
+		return fmt.Errorf("could not retrieve function (manifest_url: %s, cid: %s): %w", req.ManifestURL, req.CID, err)
+	}
+
+	// Create the response.
+	res := response.InstallFunction{
+		Type:    blockless.MessageInstallFunctionResponse,
+		Code:    response.CodeAccepted,
+		Message: "installed",
+	}
+
+	// Reply to the caller.
+	err = n.send(ctx, from, res)
+	if err != nil {
+		return fmt.Errorf("could not send the response (peer: %s): %w", from, err)
+	}
+
+	return nil
+}
+
+func (n *Node) processInstallFunctionResponse(ctx context.Context, from peer.ID, payload []byte) error {
+	n.log.Debug().Msg("function install response received")
+	return nil
+}

--- a/node/health.go
+++ b/node/health.go
@@ -1,0 +1,43 @@
+package node
+
+import (
+	"context"
+	"time"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/response"
+)
+
+const (
+	// how often should we publish the health ping.
+	healthInterval = 1 * time.Minute
+)
+
+// HealthPing will run a long running loop, publishing health signal until cancelled.
+func (n *Node) HealthPing(ctx context.Context) {
+
+	ticker := time.NewTicker(healthInterval)
+
+	for {
+		select {
+
+		case <-ticker.C:
+
+			msg := response.Health{
+				Type: blockless.MessageHealthCheck,
+				Code: response.CodeOK,
+			}
+
+			err := n.publish(ctx, msg)
+			if err != nil {
+				n.log.Warn().Err(err).Msg("could not publish health signal")
+			}
+
+			n.log.Debug().Msg("emitted health ping")
+
+		case <-ctx.Done():
+			n.log.Info().Msg("stopping health ping")
+			return
+		}
+	}
+}

--- a/node/internal/cache/cache.go
+++ b/node/internal/cache/cache.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+// Cache is a simple cache storing execution responses in memory.
+type Cache struct {
+	sync.Mutex
+	m map[string]execute.Result
+}
+
+// New creates a new cache.
+func New() *Cache {
+	c := Cache{
+		m: make(map[string]execute.Result),
+	}
+	return &c
+}
+
+// Get retrieves an execution response from the cache, given its requestID.
+func (c *Cache) Get(id string) (execute.Result, bool) {
+	c.Lock()
+	defer c.Unlock()
+
+	res, ok := c.m[id]
+	return res, ok
+}
+
+// Set caches the given execution response.
+func (c *Cache) Set(id string, res execute.Result) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.m[id] = res
+}

--- a/node/message.go
+++ b/node/message.go
@@ -1,0 +1,44 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// send serializes the message and sends it to the specified peer.
+func (n *Node) send(ctx context.Context, to peer.ID, msg interface{}) error {
+
+	// Serialize the message.
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("could not encode record: %w", err)
+	}
+
+	// Send message.
+	err = n.host.SendMessage(ctx, to, payload)
+	if err != nil {
+		return fmt.Errorf("could not send message: %w", err)
+	}
+
+	return nil
+}
+
+func (n *Node) publish(ctx context.Context, msg interface{}) error {
+
+	// Serialize the message.
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("could not encode record: %w", err)
+	}
+
+	// Publish message.
+	err = n.host.Publish(ctx, n.topic, payload)
+	if err != nil {
+		return fmt.Errorf("could not publish message: %w", err)
+	}
+
+	return nil
+}

--- a/node/node.go
+++ b/node/node.go
@@ -1,0 +1,102 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/rs/zerolog"
+
+	"github.com/blocklessnetworking/b7s/host"
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetworking/b7s/node/internal/cache"
+)
+
+// Node is the entity that actually provides the main Blockless node functionality.
+// It listens for messages coming from the wire and processes them. Depending on the
+// node role, which is determined on construction, it may process messages in different ways.
+// For example, upon receiving a message requesting execution of a Blockless function,
+// a Worker Node will use the `Execute` component to fullfill the execution request.
+// On the other hand, a Head Node will issue a roll call and eventually
+// delegate the execution to the chosend Worker Node.
+type Node struct {
+	role      blockless.NodeRole
+	topicName string
+
+	log      zerolog.Logger
+	host     *host.Host
+	store    Store
+	execute  Executor
+	function FunctionStore
+	excache  *cache.Cache
+
+	topic *pubsub.Topic
+
+	rollCallResponses map[string](chan response.RollCall)
+	executeResponses  map[string](chan response.Execute)
+}
+
+// New creates a new Node.
+func New(log zerolog.Logger, host *host.Host, store Store, peerStore PeerStore, function FunctionStore, options ...Option) (*Node, error) {
+
+	// Initialize config.
+	cfg := DefaultConfig
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	// If we're a head node, we don't have an executor.
+	if cfg.Role == blockless.HeadNode && cfg.Execute != nil {
+		return nil, errors.New("head node does not support execution")
+	}
+
+	n := Node{
+		role:      cfg.Role,
+		topicName: cfg.Topic,
+		excache:   cache.New(),
+
+		log:      log,
+		host:     host,
+		store:    store,
+		function: function,
+		execute:  cfg.Execute,
+
+		rollCallResponses: make(map[string](chan response.RollCall)),
+		executeResponses:  make(map[string](chan response.Execute)),
+	}
+
+	// Create a notifiee with a backing peerstore.
+	cn := newConnectionNotifee(log, peerStore)
+	host.Network().Notify(cn)
+
+	return &n, nil
+}
+
+// getHandler returns the appropriate handler function for the given message.
+func (n Node) getHandler(msgType string) HandlerFunc {
+
+	switch msgType {
+	case blockless.MessageHealthCheck:
+		return n.processHealthCheck
+	case blockless.MessageExecute:
+		return n.processExecute
+	case blockless.MessageExecuteResponse:
+		return n.processExecuteResponse
+	case blockless.MessageRollCall:
+		return n.processRollCall
+	case blockless.MessageRollCallResponse:
+		return n.processRollCallResponse
+	case blockless.MessageInstallFunction:
+		return n.processInstallFunction
+	case blockless.MessageInstallFunctionResponse:
+		return n.processInstallFunctionResponse
+
+	default:
+		return func(_ context.Context, from peer.ID, _ []byte) error {
+			return fmt.Errorf("received an unsupported message (type: %s, from: %s)", msgType, from.String())
+		}
+	}
+}

--- a/node/notifiee.go
+++ b/node/notifiee.go
@@ -1,0 +1,60 @@
+package node
+
+import (
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/rs/zerolog"
+)
+
+// TODO: Potentially move to internal package.
+type connectionNotifiee struct {
+	log   zerolog.Logger
+	peers PeerStore
+}
+
+func newConnectionNotifee(log zerolog.Logger, peerStore PeerStore) *connectionNotifiee {
+
+	cn := connectionNotifiee{
+		log:   log,
+		peers: peerStore,
+	}
+
+	return &cn
+}
+
+func (n *connectionNotifiee) Connected(network network.Network, conn network.Conn) {
+
+	// Get peer information.
+	peerID := conn.RemotePeer()
+	maddr := conn.RemoteMultiaddr()
+	addrInfo := network.Peerstore().PeerInfo(peerID)
+
+	n.log.Debug().
+		Str("id", peerID.String()).
+		Str("addr", maddr.String()).
+		Msg("peer connected")
+
+	// Store the peer info.
+	err := n.peers.Store(peerID, maddr, addrInfo)
+	if err != nil {
+		n.log.Warn().Err(err).Str("id", peerID.String()).Msg("could not add peer to peerstore")
+	}
+
+	// Update peer list.
+	err = n.peers.UpdatePeerList(peerID, maddr, addrInfo)
+	if err != nil {
+		n.log.Warn().Err(err).Str("id", peerID.String()).Msg("could not update peers in peerstore")
+	}
+}
+
+func (n *connectionNotifiee) Disconnected(_ network.Network, _ network.Conn) {
+	// TBD: Not implemented
+}
+
+func (n *connectionNotifiee) Listen(_ network.Network, _ multiaddr.Multiaddr) {
+	// TBD: Not implemented
+}
+
+func (n *connectionNotifiee) ListenClose(_ network.Network, _ multiaddr.Multiaddr) {
+	// TBD: Not implemented
+}

--- a/node/params.go
+++ b/node/params.go
@@ -1,0 +1,14 @@
+package node
+
+import (
+	"time"
+)
+
+const (
+	DefaultTopic = "blockless/b7s/general"
+
+	functionInstallTimeout = 10 * time.Second
+	rollCallTimeout        = 5 * time.Second
+
+	resultBufferSize = 10
+)

--- a/node/peerstore.go
+++ b/node/peerstore.go
@@ -1,0 +1,11 @@
+package node
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type PeerStore interface {
+	Store(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
+	UpdatePeerList(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
+}

--- a/node/process.go
+++ b/node/process.go
@@ -1,0 +1,46 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// processMessage will determine which message was received and how to process it.
+func (n *Node) processMessage(ctx context.Context, from peer.ID, payload []byte) error {
+
+	// Determine message type.
+	msgType, err := getMessageType(payload)
+	if err != nil {
+		return fmt.Errorf("could not determine message type: %w", err)
+	}
+
+	n.log.Debug().
+		Str("peer", from.String()).
+		Str("message", msgType).
+		Msg("received message from peer")
+
+	// Get the registered handler for the message.
+	handler := n.getHandler(msgType)
+
+	// Invoke the aprropriate handler to process the message.
+	return handler(ctx, from, payload)
+}
+
+type baseMessage struct {
+	Type string `json:"type,omitempty"`
+}
+
+// getMessageType will return the `type` string field from the JSON payload.
+func getMessageType(payload []byte) (string, error) {
+
+	var message baseMessage
+	err := json.Unmarshal(payload, &message)
+	if err != nil {
+		return "", fmt.Errorf("could not unmarshal message: %w", err)
+	}
+
+	return message.Type, nil
+}

--- a/node/rest.go
+++ b/node/rest.go
@@ -1,0 +1,104 @@
+package node
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetworking/b7s/models/request"
+)
+
+// TODO: Consider introducing an entity - a `delegator`. This could be like an Executor, only
+// instead of local execution, it would issue a roll call and delegate work to the worker nodes.
+// Problem is that delegator would need to be notified when an execution result has arrived.
+// Doing this way would make the execution flow more streamlined and would not differentiate as much between
+// worker and head node.
+func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request) (execute.Result, error) {
+
+	switch n.role {
+	case blockless.WorkerNode:
+		return n.workerExecute(ctx, n.host.ID(), req)
+
+	case blockless.HeadNode:
+		return n.headExecute(ctx, n.host.ID(), req)
+	}
+
+	panic(fmt.Errorf("invalid node role: %s", n.role))
+}
+
+// ExecutionResult fetches the execution result from the node cache.
+func (n *Node) ExecutionResult(id string) (execute.Result, bool) {
+	res, ok := n.excache.Get(id)
+	return res, ok
+}
+
+// FunctionInstall initiates function install process.
+func (n *Node) FunctionInstall(ctx context.Context, uri string, cid string) error {
+
+	var req request.InstallFunction
+	if uri != "" {
+		var err error
+		req, err = createInstallMessageFromURI(uri)
+		if err != nil {
+			return fmt.Errorf("could not create install message from URI: %W", err)
+		}
+	} else {
+		req = createInstallMessageFromCID(cid)
+	}
+
+	n.log.Debug().
+		Str("url", req.ManifestURL).
+		Str("cid", req.CID).
+		Msg("publishing function install message")
+
+	err := n.publish(ctx, req)
+	if err != nil {
+		return fmt.Errorf("could not publish message: %w", err)
+	}
+
+	return nil
+}
+
+// createInstallMessageFromURI creates a MsgInstallFunction from the given URI.
+// CID is calculated as a SHA-256 hash of the URI.
+func createInstallMessageFromURI(uri string) (request.InstallFunction, error) {
+
+	cid, err := deriveCIDFromURI(uri)
+	if err != nil {
+		return request.InstallFunction{}, fmt.Errorf("could not determine cid: %w", err)
+	}
+
+	msg := request.InstallFunction{
+		Type:        blockless.MessageInstallFunction,
+		ManifestURL: uri,
+		CID:         cid,
+	}
+
+	return msg, nil
+}
+
+// createInstallMessageFromCID creates the MsgInstallFunction from the given CID.
+func createInstallMessageFromCID(cid string) request.InstallFunction {
+
+	req := request.InstallFunction{
+		Type:        blockless.MessageInstallFunction,
+		ManifestURL: fmt.Sprintf("https://%s.ipfs.w3s.link/manifest.json", cid),
+		CID:         cid,
+	}
+
+	return req
+}
+
+func deriveCIDFromURI(uri string) (string, error) {
+
+	h := sha256.New()
+	_, err := h.Write([]byte(uri))
+	if err != nil {
+		return "", fmt.Errorf("could not calculate hash: %w", err)
+	}
+	cid := fmt.Sprintf("%x", h.Sum(nil))
+
+	return cid, nil
+}

--- a/node/roll_call.go
+++ b/node/roll_call.go
@@ -1,0 +1,120 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/request"
+	"github.com/blocklessnetworking/b7s/models/response"
+)
+
+func (n *Node) processRollCall(ctx context.Context, from peer.ID, payload []byte) error {
+
+	// Only workers respond to roll calls at the moment.
+	if n.role != blockless.WorkerNode {
+		n.log.Debug().Msg("skipping roll call as a non-worker node")
+		return nil
+	}
+
+	// Unpack the request.
+	var req request.RollCall
+	err := json.Unmarshal(payload, &req)
+	if err != nil {
+		return fmt.Errorf("could not unpack request: %w", err)
+	}
+	req.From = from
+
+	// Check if we have this manifest.
+	functionInstalled, err := n.isFunctionInstalled(req.FunctionID)
+	if err != nil {
+		// We could not lookup the manifest.
+		res := response.RollCall{
+			Type:       blockless.MessageRollCallResponse,
+			FunctionID: req.FunctionID,
+			RequestID:  req.RequestID,
+			Code:       response.CodeError,
+		}
+
+		err = n.send(ctx, req.From, res)
+		if err != nil {
+			return fmt.Errorf("could not send response: %w", err)
+		}
+
+		return fmt.Errorf("could not check if function is installed: %w", err)
+	}
+
+	// We don't have this function.
+	if !functionInstalled {
+
+		res := response.RollCall{
+			Type:       blockless.MessageRollCallResponse,
+			FunctionID: req.FunctionID,
+			RequestID:  req.RequestID,
+			Code:       response.CodeNotFound,
+		}
+
+		err = n.send(ctx, req.From, res)
+		if err != nil {
+			return fmt.Errorf("could not send response: %w", err)
+		}
+
+		// TODO: In the original code we create a function install call here.
+		// However, we do it with the CID only, but the function install code
+		// requires manifestURL + CID. So at the moment this code path is not
+		// present here.
+
+		return nil
+	}
+
+	// Create response.
+	res := response.RollCall{
+		Type:       blockless.MessageRollCallResponse,
+		FunctionID: req.FunctionID,
+		RequestID:  req.RequestID,
+		Code:       response.CodeAccepted,
+	}
+
+	// Send message.
+	err = n.send(ctx, req.From, res)
+	if err != nil {
+		return fmt.Errorf("could not send response: %w", err)
+	}
+
+	return nil
+}
+
+// issueRollCall will create a roll call request for executing the given function.
+// On successful issuance of the roll call request, we return the ID of the issued request.
+func (n *Node) issueRollCall(ctx context.Context, functionID string) (string, error) {
+
+	// Generate a new request/executionID.
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return "", fmt.Errorf("could not generate new requestID: %w", err)
+	}
+	requestID := uuid.String()
+
+	// Create a channel for receiving roll call replies.
+	// We create a bufferred channel so issuing a roll call response does not block the sender.
+	n.rollCallResponses[requestID] = make(chan response.RollCall, resultBufferSize)
+
+	// Create a roll call request.
+	rollCall := request.RollCall{
+		Type:       blockless.MessageRollCall,
+		FunctionID: functionID,
+		RequestID:  requestID,
+	}
+
+	// Publish the mssage.
+	err = n.publish(ctx, rollCall)
+	if err != nil {
+		return "", fmt.Errorf("could not publish to topic: %w", err)
+	}
+
+	return requestID, nil
+}

--- a/node/run.go
+++ b/node/run.go
@@ -1,0 +1,104 @@
+package node
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/libp2p/go-libp2p/core/network"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+)
+
+// Run will start the main loop for the node.
+func (n *Node) Run(ctx context.Context) error {
+
+	// Subscribe to the specified topic.
+	topic, subscription, err := n.host.Subscribe(ctx, n.topicName)
+	if err != nil {
+		return fmt.Errorf("could not subscribe to topic: %w", err)
+	}
+	n.topic = topic
+
+	// Set the handler for direct messages.
+	n.listenDirectMessages(ctx)
+
+	// Discover peers.
+	// NOTE: Potentially signal any error here so that we abort the node
+	// run loop if anything failed.
+	go func() {
+		err = n.host.DiscoverPeers(ctx, n.topicName)
+		if err != nil {
+			n.log.Error().
+				Err(err).
+				Msg("could not discover peers")
+		}
+	}()
+
+	// Start the health signal emitter in a separate goroutine.
+	go n.HealthPing(ctx)
+
+	n.log.Info().Msg("starting node main loop")
+
+	// Message processing loop.
+	for {
+
+		// Retrieve next message.
+		msg, err := subscription.Next(ctx)
+		if err != nil {
+			// NOTE: Cancelling the context will lead us here.
+			n.log.Error().Err(err).Msg("could not receive message")
+			break
+		}
+
+		// Skip messages we published.
+		if msg.ReceivedFrom == n.host.ID() {
+			continue
+		}
+
+		n.log.Debug().
+			Str("id", msg.ID).
+			Str("peer_id", msg.ReceivedFrom.String()).
+			Msg("received message")
+
+		err = n.processMessage(ctx, msg.ReceivedFrom, msg.Data)
+		if err != nil {
+			n.log.Error().
+				Err(err).
+				Str("id", msg.ID).
+				Str("peer_id", msg.ReceivedFrom.String()).
+				Msg("could not process message")
+			continue
+		}
+	}
+
+	return nil
+}
+
+// listenDirectMessages will process messages sent directly to the peer (as opposed to published messages).
+func (n *Node) listenDirectMessages(ctx context.Context) {
+
+	n.host.SetStreamHandler(blockless.ProtocolID, func(stream network.Stream) {
+		defer stream.Close()
+
+		from := stream.Conn().RemotePeer()
+
+		buf := bufio.NewReader(stream)
+		msg, err := buf.ReadBytes('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			stream.Reset()
+			n.log.Error().Err(err).Msg("error receiving direct message")
+			return
+		}
+
+		err = n.processMessage(ctx, from, msg)
+		if err != nil {
+			n.log.Error().
+				Err(err).
+				Str("peer_id", from.String()).
+				Msg("could not process direct message")
+		}
+	})
+}

--- a/node/store.go
+++ b/node/store.go
@@ -1,0 +1,6 @@
+package node
+
+type Store interface {
+	GetRecord(string, interface{}) error
+	SetRecord(string, interface{}) error
+}


### PR DESCRIPTION
This PR introduces the main `node` type and functionality. It builds on a number of other, currently open PRs - `storage`, `executor`, `function` handler, `peerstore` etc. It also splits and refactors models for better consistency and readability.

### Node Construction

After initializing dependencies, the `Node` handler can be constructed like so:

```go
node, err := node.New(log, host, store, peerstore, functionHandler,
		node.WithRole(role),
		node.WithExecutor(executor),
)
	if err != nil {
		log.Error().Err(err).Msg("could not create node")
		return failure
	}
```
Executor is an optional component as it's only needed by the worker nodes. The head node do not need to have `blockless` runtime locally available.

There's a few other things that make sense to make configurable - currently configurable options are `topic`, `executor` and `role`. 

### Components

#### Logger

`zerolog.Logger` - for structured, JSON logging

#### Host

The `b7s/host` handler, exposing libp2p functionality.

#### Store

Store provides read/write access to an underlying database.

```go
type Store interface {
	GetRecord(string, interface{}) error
	SetRecord(string, interface{}) error
}
```

#### Peer Store

Peer Store is used to persist known peers (e.g. on connection):

```go
type PeerStore interface {
	Store(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
	UpdatePeerList(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
}
```

#### Function Store

Function store deals with retrieving function manifests. It can force download of a function manifest, or it can use a cached one (read from DB).

```go
type FunctionStore interface {
	Get(address string, cid string, useCached bool) (*blockless.FunctionManifest, error)
}
```

#### Executor

Executor is used to run executables on the local system (`blockless-cli`). Naming hints at use like `node.execute.function(<request>)`

```go
type Executor interface {
	Function(execute.Request) (execute.Result, error)
}
```

### Models

Models are split accross multiple packages, hinting at their intended use:

- github.com/blocklessnetworking/b7s/models/request - requests/input data
- github.com/blocklessnetworking/b7s/models/response - responses/output

For example, when processing an `install function` message, you'd typically do:

```go
import (
	"github.com/blocklessnetworking/b7s/models/request"
	"github.com/blocklessnetworking/b7s/models/response"
)

func doStuff() {
	var req request.InstallFunction
	// install and process data

	// create output data
	res := response.InstallFunction{
			Type:    blockless.MessageInstallFunctionResponse,
			Code:    response.CodeAccepted,
		Message: "installed",
	}

	// send data
}
```

Some models are somewhat duplicated - mainly the `execute.Request` and `execute.Response` - I've left them split since there are slight differences between the models and their use. It might make sense to trim down the `execute` models further and trim the fat.

### Execution

Like before, we determine message handler dynamically - based on the message ID. At the moment, we (like before) process messages sequentially. In reality, we would do it in parallel by spinning up a goroutine for each message. We might want to limit to a certain number of workers (goroutines) to avoid potentially having too many active at the same time.

Also, there's a lot of room for improvement for the execution flow - I was playing around with the idea of introducing a `delegator` that would provide the same interface for execution on worker and head node; then the node code would only need to say `node.execute.function()` and the underlying interface would automagically determine what to do - execute `blockless-cli` or start a roll call, task a worker for execution and wait for execution response.

### Execution Result Caching

Execution Results are now cached - and returned from cache, on both the worker and head nodes.


### Rest API

Rest API is an entirely external component. I'm rethinking this as it might make more sense to just have it inside the node after all.

### Naming

Overarching models - used thoughout the repo, are in `models/blockless/*.go`. This means that the models are referred to by name as e.g. `blockless.HeadNode`, `blockless.Protocol` or `blockless.Peer`. However, I think it may be a bit too _grandiose_ a term, as those are really models only used within this repo. It might make more sense to rename it to `b7s` and use it as `b7s.Peer` or `b7s.Protocol` after.

### Usage and Documentation

Better documentation is on the way, regarding usage: I find it nicer/more explicit to have CLI options and plainly SEE what's being executed, vs it being hidden away in a config file. One thing that I'm not sure is as nice is specifying _boot nodes_ - as a CLI flag they're a comma separated list, but I have the feeling that it can be a long one to manage on the CLI. That's the main thing that I felt was cleaner as a file. Perhaps the boot nodes only can be specified as a filepath, with a one-node-per-line format? I dunno, let me know what you think.

Right now an example usage would be:

```bash
node --log-level debug --db path/to/db --private-key path/to/key --role head --boot-nodes node1,node2 --workspace /path/to/workspace --runtime /path/to/runtime/where/blockless-cli-is --rest-api ':8080'
```

### API paths

API code is in a separe PR, but the `api` initialization is in the `node` main executable. Note that the PATHs and HTTP methods used for some of them are changed.

### Tests

TBD