### PR TITLE
Add API handlers

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"github.com/rs/zerolog"
+)
+
+// API provides REST API functionality for the Blockless head node.
+type API struct {
+	log  zerolog.Logger
+	node Node
+}
+
+// New creates a new instance of a Blockless head node REST API. Access to node data is provided by the provided `node`.
+func New(log zerolog.Logger, node Node) *API {
+
+	api := API{
+		log:  log,
+		node: node,
+	}
+
+	return &api
+}

--- a/api/execute.go
+++ b/api/execute.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/blocklessnetworking/b7s/models/api/request"
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+// Execute implements the REST API endpoint for function execution.
+func (a *API) Execute(ctx echo.Context) error {
+
+	// Unpack the API request.
+	var req request.Execute
+	err := ctx.Bind(&req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("could not unpack request: %w", err))
+	}
+
+	// TODO: Check - We perhaps want to return the request ID and not wait for the execution, right?
+	// It's probable that it will time out anyway, right?
+
+	// Get the execution result.
+	result, err := a.node.ExecuteFunction(ctx.Request().Context(), execute.Request(req))
+	// Determine status code.
+	code := http.StatusOK
+	if err != nil {
+		code = http.StatusInternalServerError
+	}
+
+	// Send the response.
+	return ctx.JSON(code, result)
+}

--- a/api/install.go
+++ b/api/install.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/blocklessnetworking/b7s/models/api/request"
+)
+
+const (
+	functionInstallTimeout = 10 * time.Second
+)
+
+func (a *API) Install(ctx echo.Context) error {
+
+	// Unpack the API request.
+	var req request.InstallFunction
+	err := ctx.Bind(&req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("could not unpack request: %w", err))
+	}
+
+	if req.URI == "" && req.CID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.New("URI or CID are required"))
+	}
+
+	// Add a deadline to the context.
+	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), functionInstallTimeout)
+	defer cancel()
+
+	// Start function install in a separate goroutine and signal when it's done.
+	fnErr := make(chan error)
+	go func() {
+		err = a.node.FunctionInstall(reqCtx, req.URI, req.CID)
+		fnErr <- err
+	}()
+
+	// Wait until either function install finishes, or request times out.
+	select {
+
+	// Context timed out.
+	case <-reqCtx.Done():
+
+		status := http.StatusRequestTimeout
+		if !errors.Is(reqCtx.Err(), context.DeadlineExceeded) {
+			status = http.StatusInternalServerError
+		}
+		return ctx.NoContent(status)
+
+	// Work done.
+	case err = <-fnErr:
+		break
+	}
+
+	// Check if function install succeeded and handle error or return response.
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("function installation failed: %w", err))
+	}
+
+	return ctx.NoContent(http.StatusOK)
+}

--- a/api/node.go
+++ b/api/node.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"context"
+
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+type Node interface {
+	ExecuteFunction(context.Context, execute.Request) (execute.Result, error)
+	ExecutionResult(id string) (execute.Result, bool)
+	FunctionInstall(ctx context.Context, uri string, cid string) error
+}

--- a/api/result.go
+++ b/api/result.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ExecutionResult implements the REST API endpoint for retrieving the result of a function execution.
+func (a *API) ExecutionResult(ctx echo.Context) error {
+
+	// Get the request ID.
+	requestID := ctx.Param("id")
+	if requestID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.New("missing request ID"))
+	}
+
+	// Lookup execution result.
+	result, ok := a.node.ExecutionResult(requestID)
+	if !ok {
+		return ctx.NoContent(http.StatusNotFound)
+	}
+
+	// Send the response back.
+	return ctx.JSON(http.StatusOK, result)
+}


### PR DESCRIPTION
This PR introduces the API handlers used for the API endpoints. For the endpoints and models implementation, please refer to the #32 or checkout the branch https://github.com/blocklessnetwork/b7s/tree/refactor-all