### PR TITLE
Add tests for function handler package

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -134,7 +134,7 @@ func run() int {
 	}
 
 	// Create function handler.
-	functionHandler := function.New(log, store, cfg.Workspace)
+	functionHandler := function.NewHandler(log, store, cfg.Workspace)
 
 	// Instantiate node.
 	node, err := node.New(log, host, store, peerstore, functionHandler, opts...)

--- a/function/deployment_internal_test.go
+++ b/function/deployment_internal_test.go
@@ -1,0 +1,121 @@
+package function
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+)
+
+func TestFunction_UpdateDeploymentInfo(t *testing.T) {
+
+	t.Run("noop - deployment info present", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			runtimeURL  = "https://example.com/runtime-address"
+			checksum    = "123456789"
+			manifestURL = "https://example.com"
+		)
+
+		manifest := blockless.FunctionManifest{
+			Runtime: blockless.Runtime{
+				URL:      runtimeURL,
+				Checksum: checksum,
+			},
+			Deployment: blockless.Deployment{
+				URI:      "",
+				Checksum: "",
+			},
+		}
+
+		err := updateDeploymentInfo(&manifest, manifestURL)
+		require.NoError(t, err)
+
+		require.Equal(t, runtimeURL, manifest.Deployment.URI)
+		require.Equal(t, checksum, manifest.Deployment.Checksum)
+	})
+	t.Run("fills in missing host or scheme info", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			runtimeURL  = "runtime-address"
+			checksum    = "123456789"
+			manifestURL = "https://example.com/manifest-address"
+		)
+
+		manifest := blockless.FunctionManifest{
+			Runtime: blockless.Runtime{
+				URL:      runtimeURL,
+				Checksum: checksum,
+			},
+			Deployment: blockless.Deployment{
+				URI:      "",
+				Checksum: "",
+			},
+		}
+
+		err := updateDeploymentInfo(&manifest, manifestURL)
+		require.NoError(t, err)
+
+		manifestAddress, err := url.Parse(manifestURL)
+		require.NoError(t, err)
+
+		deploymentURL := url.URL{
+			Host:   manifestAddress.Host,
+			Scheme: manifestAddress.Scheme,
+			Path:   runtimeURL,
+		}
+
+		require.Equal(t, deploymentURL.String(), manifest.Deployment.URI)
+		require.Equal(t, checksum, manifest.Deployment.Checksum)
+	})
+	t.Run("handles malformed runtime URL", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			runtimeURL  = "http://example.com/runtime-address\n"
+			checksum    = "123456789"
+			manifestURL = "https://example.com/manifest-address"
+		)
+
+		manifest := blockless.FunctionManifest{
+			Runtime: blockless.Runtime{
+				URL:      runtimeURL,
+				Checksum: checksum,
+			},
+			Deployment: blockless.Deployment{
+				URI:      "",
+				Checksum: "",
+			},
+		}
+
+		err := updateDeploymentInfo(&manifest, manifestURL)
+		require.Error(t, err)
+	})
+	t.Run("handles malformed manifest URL", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			runtimeURL  = "http://example.com/runtime-address"
+			checksum    = "123456789"
+			manifestURL = "https://example.com/manifest-address\r"
+		)
+
+		manifest := blockless.FunctionManifest{
+			Runtime: blockless.Runtime{
+				URL:      runtimeURL,
+				Checksum: checksum,
+			},
+			Deployment: blockless.Deployment{
+				URI:      "",
+				Checksum: "",
+			},
+		}
+
+		err := updateDeploymentInfo(&manifest, manifestURL)
+		require.Error(t, err)
+	})
+}

--- a/function/function.go
+++ b/function/function.go
@@ -18,8 +18,8 @@ type Handler struct {
 	workdir string
 }
 
-// New creates a new function handler.
-func New(log zerolog.Logger, store Store, workdir string) *Handler {
+// NewHandler creates a new function handler.
+func NewHandler(log zerolog.Logger, store Store, workdir string) *Handler {
 
 	// Create an HTTP client.
 	cli := http.Client{

--- a/function/get_test.go
+++ b/function/get_test.go
@@ -1,0 +1,192 @@
+package function_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/function"
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/store"
+	"github.com/blocklessnetworking/b7s/testing/helpers"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestFunction_Get(t *testing.T) {
+
+	const (
+		manifestURL = "manifest.json"
+		functionURL = "function.tar.gz"
+		testFile    = "testdata/testFunction.tar.gz"
+
+		testCID = "dummy-cid"
+	)
+
+	workdir, err := os.MkdirTemp("", "b7s-function-get-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(workdir)
+
+	functionPayload, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+
+	hash := sha256.Sum256(functionPayload)
+
+	// We'll create two servers, so we can link one to the other.
+	msrv, fsrv := createServers(t, manifestURL, functionURL, functionPayload)
+
+	store := store.New(helpers.InMemoryDB(t))
+	fh := function.NewHandler(mocks.NoopLogger, store, workdir)
+
+	address := fmt.Sprintf("%s/%v", msrv.URL, manifestURL)
+	manifest, err := fh.Get(address, testCID, false)
+	require.NoError(t, err)
+
+	// Verify downloaded file.
+	archive := manifest.Deployment.File
+	require.FileExists(t, archive)
+
+	ok := verifyFileHash(t, archive, hash)
+	require.Truef(t, ok, "file hash does not match")
+
+	// Shutdown both servers and retry getting the manifest - verify that the cached manifest will be returned.
+	fsrv.Close()
+	msrv.Close()
+
+	_, err = fh.Get(address, testCID, true)
+	require.NoError(t, err)
+}
+
+func TestFunction_GetHandlesErrors(t *testing.T) {
+
+	const (
+		manifestURL = "manifest.json"
+		functionURL = "function.tar.gz"
+		testFile    = "testdata/testFunction.tar.gz"
+
+		testCID = "dummy-cid"
+	)
+
+	functionPayload, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+
+	// We'll create two servers, so we can link one to the other.
+	msrv, fsrv := createServers(t, manifestURL, functionURL, functionPayload)
+	// NOTE: Server shutdown handled in test cases below.
+
+	t.Run("handles failure to read manifest from store", func(t *testing.T) {
+
+		workdir, err := os.MkdirTemp("", "b7s-function-get-")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(workdir)
+
+		store := mocks.BaselineStore(t)
+		store.GetRecordFunc = func(string, interface{}) error {
+			return mocks.GenericError
+		}
+
+		fh := function.NewHandler(mocks.NoopLogger, store, workdir)
+
+		address := fmt.Sprintf("%s/%v", msrv.URL, manifestURL)
+		_, err = fh.Get(address, testCID, false)
+		require.Error(t, err)
+	})
+	t.Run("handles failure to download function", func(t *testing.T) {
+
+		// Shutdown function server.
+		fsrv.Close()
+
+		workdir, err := os.MkdirTemp("", "b7s-function-get-")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(workdir)
+
+		store := store.New(helpers.InMemoryDB(t))
+		fh := function.NewHandler(mocks.NoopLogger, store, workdir)
+
+		address := fmt.Sprintf("%s/%v", msrv.URL, manifestURL)
+		_, err = fh.Get(address, testCID, false)
+		require.Error(t, err)
+	})
+	t.Run("handles failure to fetch manifest", func(t *testing.T) {
+
+		// Shutdown manifest server.
+		msrv.Close()
+
+		workdir, err := os.MkdirTemp("", "b7s-function-get-")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(workdir)
+
+		store := store.New(helpers.InMemoryDB(t))
+		fh := function.NewHandler(mocks.NoopLogger, store, workdir)
+
+		address := fmt.Sprintf("%s/%v", msrv.URL, manifestURL)
+		_, err = fh.Get(address, testCID, false)
+		require.Error(t, err)
+	})
+}
+
+func createServers(t *testing.T, manifestURL string, functionURL string, functionPayload []byte) (manifestSrv *httptest.Server, functionSrv *httptest.Server) {
+	t.Helper()
+
+	// Create function server.
+	fsrv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			path := strings.TrimPrefix(req.URL.Path, "/")
+			if path != functionURL {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			w.Write(functionPayload)
+		}))
+
+	// Setup manifest that points to the function server.
+	functionAddress := fmt.Sprintf("%s/%s", fsrv.URL, functionURL)
+	hash := sha256.Sum256(functionPayload)
+	sourceManifest := blockless.FunctionManifest{
+		Deployment: blockless.Deployment{
+			URI:      functionAddress,
+			Checksum: fmt.Sprintf("%x", hash),
+		},
+	}
+
+	// Create manifest server.
+	msrv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			path := strings.TrimPrefix(req.URL.Path, "/")
+			if path != manifestURL {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			payload, err := json.Marshal(sourceManifest)
+			require.NoError(t, err)
+			w.Write(payload)
+		}))
+
+	return msrv, fsrv
+}
+
+func verifyFileHash(t *testing.T, filename string, checksum [32]byte) bool {
+	t.Helper()
+
+	data, err := os.ReadFile(filename)
+	require.NoError(t, err)
+
+	h := sha256.Sum256(data)
+
+	return bytes.Equal(checksum[:], h[:])
+}

--- a/function/gzip_internal_test.go
+++ b/function/gzip_internal_test.go
@@ -1,0 +1,50 @@
+package function
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/store"
+	"github.com/blocklessnetworking/b7s/testing/helpers"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestFunction_UnpackArchive(t *testing.T) {
+
+	const (
+		filename = "testdata/testFunction.tar.gz"
+	)
+
+	workdir, err := os.MkdirTemp("", "b7s-function-unpack-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(workdir)
+
+	store := store.New(helpers.InMemoryDB(t))
+	fh := NewHandler(mocks.NoopLogger, store, workdir)
+
+	err = fh.unpackArchive(filename, workdir)
+	require.NoError(t, err)
+}
+
+func TestFunction_UnpackArchiveHandlesErrors(t *testing.T) {
+	t.Run("handles missing archive", func(t *testing.T) {
+
+		const (
+			filename = "testdata/nonExistantFile.tar.gz"
+		)
+
+		workdir, err := os.MkdirTemp("", "b7s-function-unpack-")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(workdir)
+
+		store := store.New(helpers.InMemoryDB(t))
+		fh := NewHandler(mocks.NoopLogger, store, workdir)
+
+		err = fh.unpackArchive(filename, workdir)
+		require.Error(t, err)
+	})
+}

--- a/function/http_internal_test.go
+++ b/function/http_internal_test.go
@@ -1,10 +1,16 @@
 package function
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -142,4 +148,151 @@ func TestFunction_GetJSONHandlesErrors(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestFunction_Download(t *testing.T) {
+
+	const (
+		size = 10_000
+	)
+
+	payload := getRandomPayload(t, size)
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Write(payload)
+		}))
+	defer srv.Close()
+
+	workdir, err := os.MkdirTemp("", "b7s-function-download-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(workdir)
+
+	store := store.New(helpers.InMemoryDB(t))
+	fh := NewHandler(mocks.NoopLogger, store, workdir)
+
+	address := fmt.Sprintf("%s/test-file", srv.URL)
+	hash := sha256.Sum256(payload)
+
+	manifest := blockless.FunctionManifest{
+		Deployment: blockless.Deployment{
+			URI:      address,
+			Checksum: fmt.Sprintf("%x", hash),
+		},
+	}
+
+	path, err := fh.download(manifest)
+	require.NoError(t, err)
+
+	// Check if the file created is within the specified workdir.
+	// Not the perfect way to check this, but it will do.
+	require.True(t, strings.HasPrefix(path, workdir))
+
+	downloaded, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	require.Equal(t, payload, downloaded)
+}
+
+func TestFunction_DownloadHandlesErrors(t *testing.T) {
+
+	const (
+		size = 10_000
+	)
+
+	payload := getRandomPayload(t, size)
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Write(payload)
+		}))
+	// NOTE: Server handled in a test case below.
+	// Also the reason tests are not executed in parallel.
+
+	t.Run("handles invalid checksum", func(t *testing.T) {
+
+		workdir, err := os.MkdirTemp("", "b7s-function-download-")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(workdir)
+
+		store := store.New(helpers.InMemoryDB(t))
+		fh := NewHandler(mocks.NoopLogger, store, workdir)
+
+		address := fmt.Sprintf("%s/test-file", srv.URL)
+		hash := sha256.Sum256(payload)
+
+		invalidChecksum := fmt.Sprintf("%x", hash) + "Z"
+
+		manifest := blockless.FunctionManifest{
+			Deployment: blockless.Deployment{
+				URI:      address,
+				Checksum: invalidChecksum,
+			},
+		}
+
+		_, err = fh.download(manifest)
+		require.Error(t, err)
+	})
+	t.Run("handles invalid URI", func(t *testing.T) {
+
+		workdir, err := os.MkdirTemp("", "b7s-function-download-")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(workdir)
+
+		store := store.New(helpers.InMemoryDB(t))
+		fh := NewHandler(mocks.NoopLogger, store, workdir)
+
+		address := fmt.Sprintf("%s/test-file", srv.URL) + "\n"
+		hash := sha256.Sum256(payload)
+
+		manifest := blockless.FunctionManifest{
+			Deployment: blockless.Deployment{
+				URI:      address,
+				Checksum: fmt.Sprintf("%x", hash),
+			},
+		}
+
+		_, err = fh.download(manifest)
+		require.Error(t, err)
+	})
+	t.Run("handles download failure", func(t *testing.T) {
+
+		srv.Close()
+
+		workdir, err := os.MkdirTemp("", "b7s-function-download-")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(workdir)
+
+		store := store.New(helpers.InMemoryDB(t))
+		fh := NewHandler(mocks.NoopLogger, store, workdir)
+
+		address := fmt.Sprintf("%s/test-file", srv.URL)
+		hash := sha256.Sum256(payload)
+
+		manifest := blockless.FunctionManifest{
+			Deployment: blockless.Deployment{
+				URI:      address,
+				Checksum: fmt.Sprintf("%x", hash),
+			},
+		}
+
+		_, err = fh.download(manifest)
+		require.Error(t, err)
+	})
+}
+
+func getRandomPayload(t *testing.T, len int) []byte {
+	t.Helper()
+
+	rand.Seed(time.Now().UnixNano())
+
+	buf := make([]byte, len)
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
+
+	return buf
 }

--- a/function/http_internal_test.go
+++ b/function/http_internal_test.go
@@ -1,0 +1,145 @@
+package function
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/store"
+	"github.com/blocklessnetworking/b7s/testing/helpers"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestFunction_GetJSON(t *testing.T) {
+
+	var (
+		workdir  = "/"
+		manifest = blockless.FunctionManifest{
+			ID:          "generic-id",
+			Name:        "generic-name",
+			Description: "generic-description",
+			Function: blockless.Function{
+				ID:      "function-id",
+				Name:    "function-name",
+				Runtime: "generic-runtime",
+			},
+			Deployment: blockless.Deployment{
+				CID:      "generic-cid",
+				Checksum: "1234567890",
+				URI:      "generic-uri",
+			},
+			FSRootPath: "/var/tmp/blockless/",
+			Entry:      "/var/tmp/blockless/app.wasm",
+		}
+	)
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			payload, err := json.Marshal(manifest)
+			require.NoError(t, err)
+			w.Write(payload)
+		}))
+	defer srv.Close()
+
+	store := store.New(helpers.InMemoryDB(t))
+	fh := NewHandler(mocks.NoopLogger, store, workdir)
+
+	var downloaded blockless.FunctionManifest
+	err := fh.getJSON(srv.URL, &downloaded)
+	require.NoError(t, err)
+
+	require.Equal(t, manifest, downloaded)
+}
+
+func TestFunction_GetJSONHandlesErrors(t *testing.T) {
+
+	const (
+		workdir = "/"
+	)
+
+	tests := []struct {
+		name string
+
+		statusCode int
+		payload    []byte
+	}{
+		{
+			name: "handles malformed JSON",
+
+			statusCode: http.StatusOK,
+			// JSON payload without closing brace.
+			payload: []byte(`{
+			"id":"generic-id",
+			"name":"generic-name",
+			"description":"generic-description",
+			"function": {
+				"id":"function-id",
+				"name":"function-name",
+				"runtime":"generic-runtime"
+			},
+			"deployment":{
+				"cid":"generic-cid",
+				"checksum":"1234567890",
+				"uri":"generic-uri"
+			},
+			"runtime":{},
+			"fs_root_path":"/var/tmp/blockless/",
+			"entry":"/var/tmp/blockless/app.wasm"`), // <- missing closing brace
+		},
+		{
+			name: "handles unexpected format",
+
+			statusCode: http.StatusOK,
+			// Valid JSON payload but wrong format - number instead of a textual fiel.d
+			payload: []byte(`{
+				"id":"generic-id",
+				"name":"generic-name",
+				"description":"generic-description",
+				"function": {
+					"id":"function-id",
+					"name":"function-name",
+					"runtime":"generic-runtime"
+				},
+				"deployment":{
+					"cid":"generic-cid",
+					"checksum":"1234567890",
+					"uri":"generic-uri"
+				},
+				"runtime":{},
+				"fs_root_path":"/var/tmp/blockless/",
+				"entry":999
+			}`),
+		},
+		{
+			name:       "handles missing data",
+			statusCode: http.StatusInternalServerError,
+			payload:    []byte{},
+		},
+	}
+
+	for _, test := range tests {
+
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					w.WriteHeader(test.statusCode)
+					w.Write(test.payload)
+				}))
+			defer srv.Close()
+
+			store := store.New(helpers.InMemoryDB(t))
+			fh := NewHandler(mocks.NoopLogger, store, workdir)
+
+			var response blockless.FunctionManifest
+			err := fh.getJSON(srv.URL, &response)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a number of tests to the function handler package. It aims to test a number of functions/methods in isolation (retrieval of manifest, downloading function code, handling archive data), but also adds tests to an external package to test the public interface of the `function.Handler` type - it's `Get()` method.

Test coverage of the package sits at 85% at the moment.

Unfortunately due to us relying on `grab` package for function download it was not possible to (easily) get around filesystem interaction for these tests, so we do create a number of temporary directories/files (unique per test case), which we do clean up afterwards.