### PR TITLE
Peer discovery phase - skip connected peers

### DIFF
--- a/host/config.go
+++ b/host/config.go
@@ -1,6 +1,8 @@
 package host
 
 import (
+	"time"
+
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -9,6 +11,7 @@ var defaultConfig = Config{
 	PrivateKey:          "",
 	ConnectionThreshold: 20,
 	DialBackPeersLimit:  100,
+	DiscoveryInterval:   10 * time.Second,
 }
 
 // Config represents the Host configuration.
@@ -18,6 +21,7 @@ type Config struct {
 	BootNodes           []multiaddr.Multiaddr
 	DialBackPeers       []multiaddr.Multiaddr
 	DialBackPeersLimit  uint
+	DiscoveryInterval   time.Duration
 }
 
 // WithPrivateKey specifies the private key for the Host.
@@ -52,5 +56,12 @@ func WithDialBackPeers(peers []multiaddr.Multiaddr) func(*Config) {
 func WithDialBackPeersLimit(n uint) func(*Config) {
 	return func(cfg *Config) {
 		cfg.DialBackPeersLimit = n
+	}
+}
+
+// WithDiscoveryInterval specifies how often we should try to discover new peers during the discovery phase.
+func WithDiscoveryInterval(d time.Duration) func(*Config) {
+	return func(cfg *Config) {
+		cfg.DiscoveryInterval = d
 	}
 }

--- a/host/dht.go
+++ b/host/dht.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -39,6 +40,15 @@ findPeers:
 				continue
 			}
 
+			// Skip peers we're already connected to.
+			connections := h.Network().ConnsToPeer(peer.ID)
+			if len(connections) > 0 {
+				h.log.Debug().
+					Str("peer", peer.String()).
+					Msg("skipping connected peer")
+				continue
+			}
+
 			err = h.Connect(ctx, peer)
 			if err != nil {
 				h.log.Debug().
@@ -57,6 +67,8 @@ findPeers:
 				break findPeers
 			}
 		}
+
+		time.Sleep(h.cfg.DiscoveryInterval)
 	}
 
 	h.log.Info().Msg("peer discovery complete")


### PR DESCRIPTION
This PR introduces a small change into the peer discovery phase. I noticed by default we kept connecting to the same host over and over again - this is because "discovered" peers list will include peers that we may be already connected to.

With the current change, we skip them, and we also introduce a small (configurable) pause in how often we try to rediscover new peers. By default the pause is set to 10s.