### PR TITLE
Better logging structure

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -14,7 +14,7 @@ type API struct {
 func New(log zerolog.Logger, node Node) *API {
 
 	api := API{
-		log:  log,
+		log:  log.With().Str("component", "api").Logger(),
 		node: node,
 	}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -22,7 +22,7 @@ func New(log zerolog.Logger, options ...Option) (*Executor, error) {
 	}
 
 	e := Executor{
-		log: log,
+		log: log.With().Str("component", "executor").Logger(),
 		cfg: cfg,
 	}
 

--- a/function/function.go
+++ b/function/function.go
@@ -31,7 +31,7 @@ func NewHandler(log zerolog.Logger, store Store, workdir string) *Handler {
 	downloader.UserAgent = defaultUserAgent
 
 	h := Handler{
-		log:        log,
+		log:        log.With().Str("component", "function_store").Logger(),
 		store:      store,
 		http:       &cli,
 		downloader: downloader,

--- a/host/host.go
+++ b/host/host.go
@@ -53,7 +53,7 @@ func New(log zerolog.Logger, address string, port uint, options ...func(*Config)
 	}
 
 	host := Host{
-		log: log,
+		log: log.With().Str("component", "host").Logger(),
 		cfg: cfg,
 	}
 	host.Host = h

--- a/node/node.go
+++ b/node/node.go
@@ -58,7 +58,7 @@ func New(log zerolog.Logger, host *host.Host, store Store, peerStore PeerStore, 
 	n := Node{
 		cfg: cfg,
 
-		log:      log,
+		log:      log.With().Str("component", "node").Logger(),
 		host:     host,
 		store:    store,
 		function: function,

--- a/node/notifiee.go
+++ b/node/notifiee.go
@@ -15,7 +15,7 @@ type connectionNotifiee struct {
 func newConnectionNotifee(log zerolog.Logger, peerStore PeerStore) *connectionNotifiee {
 
 	cn := connectionNotifiee{
-		log:   log,
+		log:   log.With().Str("component", "notifiee").Logger(),
 		peers: peerStore,
 	}
 


### PR DESCRIPTION
Each component with a logger (e.g. node, executor) adds a `component` field to its log entries, so that the logs could be more easily filtered/parsed.