### PR TITLE
Node processes requests in parallel

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -15,6 +15,7 @@ var DefaultConfig = Config{
 	Topic:           DefaultTopic,
 	HealthInterval:  DefaultHealthInterval,
 	RollCallTimeout: DefaultRollCallTimeout,
+	Concurrency:     DefaultConcurrency,
 }
 
 // Config represents the Node configuration.
@@ -24,6 +25,7 @@ type Config struct {
 	Execute         Executor           // Executor to use for running functions.
 	HealthInterval  time.Duration      // How often should we emit the health ping.
 	RollCallTimeout time.Duration      // How long do we wait for roll call responses.
+	Concurrency     uint               // How many requests should the node process in parallel.
 }
 
 // WithRole specifies the role for the node.
@@ -58,5 +60,12 @@ func WithHealthInterval(d time.Duration) Option {
 func WithRollCallTimeout(d time.Duration) Option {
 	return func(cfg *Config) {
 		cfg.RollCallTimeout = d
+	}
+}
+
+// WithConcurrency specifies how many requests the node should process in parallel.
+func WithConcurrency(n uint) Option {
+	return func(cfg *Config) {
+		cfg.Concurrency = n
 	}
 }

--- a/node/params.go
+++ b/node/params.go
@@ -9,6 +9,7 @@ const (
 	DefaultTopic           = "blockless/b7s/general"
 	DefaultHealthInterval  = 1 * time.Minute
 	DefaultRollCallTimeout = 5 * time.Second
+	DefaultConcurrency     = 10
 
 	functionInstallTimeout = 10 * time.Second
 


### PR DESCRIPTION
This PR makes a slight adjustment to how the incoming messages are processed. So far requests were executed one by one, while now we execute requests in parallel. Parallelism in a configurable option, currently set to 10 by default.  (I have no good feeling right now what is a good value for it.)