### PR TITLE
Concurrency level for the node can be set using the CLI flag

### DIFF
--- a/cmd/node/README.md
+++ b/cmd/node/README.md
@@ -23,6 +23,7 @@ Head Nodes also serve a REST API that can be used to query or trigger certain ac
 Usage of node:
   -a, --address string       address that the libp2p host will use (default "0.0.0.0")
       --boot-nodes strings   list of addresses that this node will connect to on startup, in multiaddr format
+  -c, --concurrency uint     maximum number of requests node will process in parallel (default 10)
   -d, --db string            path to the database used for persisting node data (default "db")
   -l, --log-level string     log level to use (default "info")
   -p, --port uint            port that the libp2p host will use

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -4,13 +4,15 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/blocklessnetworking/b7s/config"
+	"github.com/blocklessnetworking/b7s/node"
 )
 
 // Default values.
 const (
-	defaultPort    = 0
-	defaultAddress = "0.0.0.0"
-	defaultDB      = "db"
+	defaultPort        = 0
+	defaultAddress     = "0.0.0.0"
+	defaultDB          = "db"
+	defaultConcurrency = uint(node.DefaultConcurrency)
 
 	defaultRole = "worker"
 )
@@ -27,6 +29,7 @@ func parseFlags() *config.Config {
 	pflag.StringVarP(&cfg.Host.Address, "address", "a", defaultAddress, "address that the libp2p host will use")
 	pflag.UintVarP(&cfg.Host.Port, "port", "p", defaultPort, "port that the libp2p host will use")
 	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the libp2p host will use")
+	pflag.UintVarP(&cfg.Concurrency, "concurrency", "c", defaultConcurrency, "maximum number of requests node will process in parallel")
 	pflag.StringVar(&cfg.API, "rest-api", "", "address where the head node REST API will listen on")
 	pflag.StringSliceVar(&cfg.BootNodes, "boot-nodes", nil, "list of addresses that this node will connect to on startup, in multiaddr format")
 

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -111,6 +111,7 @@ func run() int {
 	// Set node options.
 	opts := []node.Option{
 		node.WithRole(role),
+		node.WithConcurrency(cfg.Concurrency),
 	}
 
 	// If this is a worker node, initialize an executor.

--- a/config/model.go
+++ b/config/model.go
@@ -6,6 +6,7 @@ type Config struct {
 	DatabasePath string
 	Role         string
 	BootNodes    []string
+	Concurrency  uint
 
 	Host    Host
 	API     string

--- a/node/run.go
+++ b/node/run.go
@@ -39,7 +39,9 @@ func (n *Node) Run(ctx context.Context) error {
 	// Start the health signal emitter in a separate goroutine.
 	go n.HealthPing(ctx)
 
-	n.log.Info().Msg("starting node main loop")
+	n.log.Info().
+		Uint("concurrency", n.cfg.Concurrency).
+		Msg("starting node main loop")
 
 	// Message processing loop.
 	for {


### PR DESCRIPTION
This PR adds a CLI flag that can be used to set the concurrency level for the node. By default it's still set to 10, so it's on by default.

Can also turn it off by default, if that's a preferred option at this moment.