### PR TITLE
change api endpoints to posts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,8 +6,23 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/src",
-      "args": ["--config", "./configs/head-config.yaml"],
+      "program": "${workspaceFolder}/cmd/node",
+      "args": [
+        "--db",
+        "/tmp/b7s/db",
+        "--log-level",
+        "debug",
+        "--port",
+        "9527",
+        "--role",
+        "head",
+        "--workspace",
+        "/tmp/debug/head",
+        "--private-key",
+        "${workspaceFolder}/configs/testkeys/ident1/priv.bin",
+        "--rest-api",
+        ":8081"
+      ],
       "cwd": "${workspaceFolder}"
     },
     {
@@ -15,8 +30,25 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/src",
-      "args": ["--config", "./configs/worker-config.yaml"],
+      "program": "${workspaceFolder}/cmd/node",
+      "args": [
+        "--db",
+        "/tmp/b7s/db-worker",
+        "--log-level",
+        "debug",
+        "--port",
+        "0",
+        "--role",
+        "worker",
+        "--runtime",
+        "/tmp/runtime",
+        "--workspace",
+        "/tmp/debug/worker",
+        "--private-key",
+        "${workspaceFolder}/configs/testkeys/ident2/priv.bin",
+        "--boot-nodes",
+        "/ip4/0.0.0.0/tcp/9527/p2p/12D3KooWH9GerdSEroL2nqjpd2GuE5dwmqNi7uHX7FoywBdKcP4q"
+      ],
       "cwd": "${workspaceFolder}"
     }
   ]

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -191,8 +191,8 @@ func run() int {
 
 		// Set endpoint handlers.
 		server.POST("/api/v1/functions/execute", api.Execute)
-		server.GET("/api/v1/functions/:id/install", api.Install)
-		server.GET("/api/v1/functions/requests/:id/result", api.ExecutionResult)
+		server.POST("/api/v1/functions/install", api.Install)
+		server.POST("/api/v1/functions/requests/result", api.ExecutionResult)
 
 		// Start API in a separate goroutine.
 		go func() {


### PR DESCRIPTION
update the vscode debug files in the mean finish. 

but switching these API endpoints back to posts, because `GET` requests would reveal too much information about the intended operating load of the Node. 