### PR TITLE
Add a docker image for integration tests

### DIFF
--- a/docker/integration-tests/Dockerfile.testing
+++ b/docker/integration-tests/Dockerfile.testing
@@ -22,5 +22,8 @@ RUN mkdir /app/runtime && tar -xvkf ./runtime.tar.gz -C /app/runtime
 # specify where runtime is installed
 ENV B7S_INTEG_RUNTIME_DIR=/app/runtime
 
+# download dependencies
+RUN go get ./...
+
 # run the tests
 CMD [ "go", "test", "--tags=integration", "-v", "./..." ]

--- a/docker/integration-tests/Dockerfile.testing
+++ b/docker/integration-tests/Dockerfile.testing
@@ -1,0 +1,26 @@
+FROM --platform=linux/amd64 ubuntu:latest 
+
+WORKDIR /app/node
+
+## copy source files
+COPY . .
+
+# curl, unzip other utilities
+RUN apt-get update && \
+  apt-get install --no-install-recommends --assume-yes curl unzip pv ca-certificates gnupg2 build-essential
+
+# install go
+RUN curl -o go1.18.3.linux-amd64.tar.gz -sSL https://go.dev/dl/go1.18.3.linux-amd64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+
+# get the runtime
+RUN curl -o ./runtime.tar.gz -sSL https://github.com/blocklessnetwork/runtime/releases/download/v0.0.12/blockless-runtime.linux-latest.x86_64.tar.gz
+RUN mkdir /app/runtime && tar -xvkf ./runtime.tar.gz -C /app/runtime
+
+
+# specify where runtime is installed
+ENV B7S_INTEG_RUNTIME_DIR=/app/runtime
+
+# run the tests
+CMD [ "go", "test", "--tags=integration", "-v", "./..." ]

--- a/node/node_internal_test.go
+++ b/node/node_internal_test.go
@@ -31,7 +31,7 @@ const (
 	// This is the pause we make after subscribing to the topic and before publishing a message.
 	// In reality as little as 250ms is enough, but lets allow a longer time for when
 	// tests are executed in parallel or on weaker machines.
-	subscriptionDiseminationPause = 1 * time.Second
+	subscriptionDiseminationPause = 2 * time.Second
 )
 
 func TestNode_New(t *testing.T) {


### PR DESCRIPTION
This PR adds a `Dockerfile.testing` that can be used to run integration tests - potentially as part of our CI.
With the regular tests only, our test coverage is 73.2%. Integration tests have two major test cases:
1. Run the executor to actually run something using Blockless Runtime (needs to be installed beforehand)
2. Run the test with two nodes, which includes creating a head and worker node, issuing an execution request to the worker node, doing roll call and waiting for the results from the worker node

With the integration tests, test coverage is upped to 82.9%.

Note that this will execute both _regular_ and integration tests, so it's a superset of the test run we do as part of the CI workflow. We may want to consider running these, so we execute as many tests as possible..