### PR TITLE
dialback address through flags

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -29,8 +29,8 @@ func parseFlags() *config.Config {
 	pflag.StringVarP(&cfg.Host.Address, "address", "a", defaultAddress, "address that the b7s host will use")
 	pflag.UintVarP(&cfg.Host.Port, "port", "p", defaultPort, "port that the b7s host will use")
 
-	pflag.StringVarP(&cfg.Host.Address, "dialback-address", "", defaultAddress, "external address that the b7s host will advertise")
-	pflag.UintVarP(&cfg.Host.Port, "dialback-port", "", defaultPort, "external port that the b7s host will advertise")
+	pflag.StringVarP(&cfg.Host.DialBackAddress, "dialback-address", "", defaultAddress, "external address that the b7s host will advertise")
+	pflag.UintVarP(&cfg.Host.DialBackPort, "dialback-port", "", defaultPort, "external port that the b7s host will advertise")
 
 	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the b7s host will use")
 	pflag.UintVarP(&cfg.Concurrency, "concurrency", "c", defaultConcurrency, "maximum number of requests node will process in parallel")

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -26,9 +26,13 @@ func parseFlags() *config.Config {
 
 	// Node configuration.
 	pflag.StringVarP(&cfg.Role, "role", "r", defaultRole, "role this note will have in the Blockless protocol (head or worker)")
-	pflag.StringVarP(&cfg.Host.Address, "address", "a", defaultAddress, "address that the libp2p host will use")
-	pflag.UintVarP(&cfg.Host.Port, "port", "p", defaultPort, "port that the libp2p host will use")
-	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the libp2p host will use")
+	pflag.StringVarP(&cfg.Host.Address, "address", "a", defaultAddress, "address that the b7s host will use")
+	pflag.UintVarP(&cfg.Host.Port, "port", "p", defaultPort, "port that the b7s host will use")
+
+	pflag.StringVarP(&cfg.Host.Address, "dialback-address", "", defaultAddress, "external address that the b7s host will advertise")
+	pflag.UintVarP(&cfg.Host.Port, "dialback-port", "", defaultPort, "external port that the b7s host will advertise")
+
+	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the b7s host will use")
 	pflag.UintVarP(&cfg.Concurrency, "concurrency", "c", defaultConcurrency, "maximum number of requests node will process in parallel")
 	pflag.StringVar(&cfg.API, "rest-api", "", "address where the head node REST API will listen on")
 	pflag.StringSliceVar(&cfg.BootNodes, "boot-nodes", nil, "list of addresses that this node will connect to on startup, in multiaddr format")

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -95,6 +95,8 @@ func run() int {
 		host.WithPrivateKey(cfg.Host.PrivateKey),
 		host.WithBootNodes(bootNodeAddrs),
 		host.WithDialBackPeers(peerAddrs),
+		host.WithDialBackAddress(cfg.Host.DialBackAddress),
+		host.WithDialBackPort(cfg.Host.DialBackPort),
 	)
 	if err != nil {
 		log.Error().Err(err).Str("key", cfg.Host.PrivateKey).Msg("could not create host")

--- a/config/model.go
+++ b/config/model.go
@@ -17,9 +17,11 @@ type Config struct {
 
 // Host describes the libp2p host that the node will use.
 type Host struct {
-	Port       uint
-	Address    string
-	PrivateKey string
+	Port            uint
+	Address         string
+	PrivateKey      string
+	DialBackPort    uint
+	DialBackAddress string
 }
 
 // Log describes the logging configuration.

--- a/host/config.go
+++ b/host/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	DialBackPeers       []multiaddr.Multiaddr
 	DialBackPeersLimit  uint
 	DiscoveryInterval   time.Duration
+	DialBackAddress     string
+	DialBackPort        uint
 }
 
 // WithPrivateKey specifies the private key for the Host.
@@ -49,6 +51,18 @@ func WithBootNodes(nodes []multiaddr.Multiaddr) func(*Config) {
 func WithDialBackPeers(peers []multiaddr.Multiaddr) func(*Config) {
 	return func(cfg *Config) {
 		cfg.DialBackPeers = peers
+	}
+}
+
+func WithDialBackAddress(a string) func(*Config) {
+	return func(cfg *Config) {
+		cfg.DialBackAddress = a
+	}
+}
+
+func WithDialBackPort(n uint) func(*Config) {
+	return func(cfg *Config) {
+		cfg.DialBackPort = n
 	}
 }
 

--- a/host/host.go
+++ b/host/host.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 // Host represents a new libp2p host.
@@ -44,6 +45,19 @@ func New(log zerolog.Logger, address string, port uint, options ...func(*Config)
 		}
 
 		opts = append(opts, libp2p.Identity(key))
+	}
+
+	if cfg.DialBackAddress != "" && cfg.DialBackPort != 0 {
+
+		// Create a multiaddr with the external IP and port
+		externalMultiaddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", cfg.DialBackAddress, cfg.DialBackPort))
+		if err != nil {
+			panic(err)
+		}
+		opts = append(opts, libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
+			// Return only the external multiaddr
+			return []ma.Multiaddr{externalMultiaddr}
+		}))
 	}
 
 	// Create libp2p host.


### PR DESCRIPTION
Advertises the DialBack Address that can be provided through CLI flags. This will allow us to advertise random port assignments for the container. If we can not access Kubernetes APIs

```json
{"level":"info","id":"12D3KooWQrN5U3BApv4JYjE5HyKXFKkRF2U8c5FgK3zMPjzkZTpQ","addresses":["/ip4/33.33.33.33/tcp/2222/p2p/12D3KooWQrN5U3BApv4JYjE5HyKXFKkRF2U8c5FgK3zMPjzkZTpQ"],"boot_nodes":1,"dial_back_peers":0,"time":"2023-03-29T12:39:10-05:00","message":"created host"}
```