### PR TITLE
Add tests for API package

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	executeEndpoint = "/api/v1/functions/execute"
-	Installndpoint  = "/api/v1/functions/install"
+	installEndpoint = "/api/v1/functions/install"
 	resultEndpoint  = "/api/v1/functions/requests/result"
 )
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,59 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/blocklessnetworking/b7s/api"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+const (
+	executeEndpoint = "/api/v1/functions/execute"
+	Installndpoint  = "/api/v1/functions/install"
+	resultEndpoint  = "/api/v1/functions/requests/result"
+)
+
+func setupAPI(t *testing.T) *api.API {
+	t.Helper()
+
+	var (
+		logger = mocks.NoopLogger
+		node   = mocks.BaselineNode(t)
+	)
+
+	api := api.New(logger, node)
+
+	return api
+}
+
+func setupRecorder(endpoint string, input interface{}, options ...func(*http.Request)) (*httptest.ResponseRecorder, echo.Context, error) {
+
+	payload, ok := input.([]byte)
+	if !ok {
+		var err error
+		payload, err = json.Marshal(input)
+		if err != nil {
+			return nil, echo.New().AcquireContext(), fmt.Errorf("could not encode input: %w", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewReader(payload))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+	for _, opt := range options {
+		opt(req)
+	}
+
+	rec := httptest.NewRecorder()
+
+	ctx := echo.New().NewContext(req, rec)
+
+	return rec, ctx, nil
+}

--- a/api/execute_test.go
+++ b/api/execute_test.go
@@ -1,0 +1,137 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/api"
+	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestAPI_Execute(t *testing.T) {
+
+	api := setupAPI(t)
+
+	req := mocks.GenericExecutionRequest
+
+	rec, ctx, err := setupRecorder(executeEndpoint, req)
+	require.NoError(t, err)
+
+	err = api.Execute(ctx)
+	require.NoError(t, err)
+
+	var res execute.Result
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	require.Equal(t, mocks.GenericExecutionResult, res)
+}
+
+func TestAPI_Execute_HandlesErrors(t *testing.T) {
+
+	executionResult := execute.Result{
+		Result: "dummy-failed-execution-result",
+	}
+
+	node := mocks.BaselineNode(t)
+	node.ExecuteFunctionFunc = func(context.Context, execute.Request) (execute.Result, error) {
+		return executionResult, mocks.GenericError
+	}
+
+	api := api.New(mocks.NoopLogger, node)
+
+	req := mocks.GenericExecutionRequest
+
+	rec, ctx, err := setupRecorder(executeEndpoint, req)
+	require.NoError(t, err)
+
+	err = api.Execute(ctx)
+	require.NoError(t, err)
+
+	var res execute.Result
+	err = json.Unmarshal(rec.Body.Bytes(), &res)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Result().StatusCode)
+	require.Equal(t, executionResult, res)
+}
+
+func TestAPI_Execute_HandlesMalformedRequests(t *testing.T) {
+
+	api := setupAPI(t)
+	_ = api
+
+	const (
+		wrongFieldType = `
+		{
+			"function_id" : "generic-function-id",
+			"method" : 14,
+			"parameters" : [ {"name":"generic-param-name","value":"generic-param-value"} ]
+		}`
+
+		unclosedBracket = `
+		{
+			"function_id" : "generic-function-id",
+			"method" : "wasm",
+			"parameters" : [ {"name":"generic-param-name","value":"generic-param-value"} ]
+		`
+
+		validJSON = `
+		{
+			"function_id" : "generic-function-id",
+			"method" : "wasm",
+			"parameters" : [ {"name":"generic-param-name","value":"generic-param-value"} ]
+		}`
+	)
+
+	tests := []struct {
+		name        string
+		payload     []byte
+		contentType string
+	}{
+		{
+			name:        "wrong field type",
+			payload:     []byte(wrongFieldType),
+			contentType: echo.MIMEApplicationJSON,
+		},
+		{
+			name:        "malformed JSON",
+			payload:     []byte(unclosedBracket),
+			contentType: echo.MIMEApplicationJSON,
+		},
+		{
+			name:    "valid JSON with no MIME type",
+			payload: []byte(validJSON),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			prepare := func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, test.contentType)
+			}
+
+			_, ctx, err := setupRecorder(executeEndpoint, test.payload, prepare)
+			require.NoError(t, err)
+
+			err = api.Execute(ctx)
+			require.Error(t, err)
+
+			echoErr, ok := err.(*echo.HTTPError)
+			require.True(t, ok)
+
+			require.Equal(t, http.StatusBadRequest, echoErr.Code)
+		})
+	}
+
+}

--- a/api/install_test.go
+++ b/api/install_test.go
@@ -1,0 +1,184 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/api"
+	"github.com/blocklessnetworking/b7s/models/api/request"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestAPI_FunctionInstall(t *testing.T) {
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		api := setupAPI(t)
+
+		req := request.InstallFunction{
+			URI: "dummy-function-id",
+			CID: "dummy-cid",
+		}
+
+		rec, ctx, err := setupRecorder(installEndpoint, req)
+		require.NoError(t, err)
+
+		err = api.Install(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	})
+}
+
+func TestAPI_FunctionInstallHandlesErrors(t *testing.T) {
+	t.Run("missing URI and CID", func(t *testing.T) {
+		t.Parallel()
+
+		api := setupAPI(t)
+
+		req := request.InstallFunction{
+			URI: "",
+			CID: "",
+		}
+
+		_, ctx, err := setupRecorder(installEndpoint, req)
+		require.NoError(t, err)
+
+		err = api.Install(ctx)
+		require.Error(t, err)
+
+		echoErr, ok := err.(*echo.HTTPError)
+		require.True(t, ok)
+
+		require.Equal(t, http.StatusBadRequest, echoErr.Code)
+	})
+	t.Run("node install takes too long", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			// The API times out after 10 seconds.
+			installDuration = 11 * time.Second
+		)
+
+		node := mocks.BaselineNode(t)
+		node.FunctionInstallFunc = func(context.Context, string, string) error {
+			time.Sleep(installDuration)
+			return nil
+		}
+
+		api := api.New(mocks.NoopLogger, node)
+
+		req := request.InstallFunction{
+			URI: "dummy-uri",
+			CID: "dummy-cid",
+		}
+
+		rec, ctx, err := setupRecorder(installEndpoint, req)
+		require.NoError(t, err)
+
+		err = api.Install(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusRequestTimeout, rec.Result().StatusCode)
+	})
+	t.Run("node fails to install function", func(t *testing.T) {
+		t.Parallel()
+
+		node := mocks.BaselineNode(t)
+		node.FunctionInstallFunc = func(context.Context, string, string) error {
+			return mocks.GenericError
+		}
+
+		api := api.New(mocks.NoopLogger, node)
+
+		req := request.InstallFunction{
+			URI: "dummy-uri",
+			CID: "dummy-cid",
+		}
+
+		_, ctx, err := setupRecorder(installEndpoint, req)
+		require.NoError(t, err)
+
+		err = api.Install(ctx)
+		require.Error(t, err)
+
+		echoErr, ok := err.(*echo.HTTPError)
+		require.True(t, ok)
+
+		require.Equal(t, http.StatusInternalServerError, echoErr.Code)
+	})
+}
+
+func TestAPI_InstallFunction_HandlesMalformedRequests(t *testing.T) {
+
+	api := setupAPI(t)
+
+	const (
+		wrongFieldType = `
+		{
+			"uri": "dummy-uri",
+			"cid": 14
+		}`
+
+		unclosedBracket = `
+		{
+			"uri": "dummy-uri",
+			"cid": "dummy-cid"
+		`
+
+		validJSON = `
+		{
+			"uri": "dummy-uri",
+			"cid": "dummy-cid"
+		}`
+	)
+
+	tests := []struct {
+		name        string
+		payload     []byte
+		contentType string
+	}{
+		{
+			name:        "wrong field type",
+			payload:     []byte(wrongFieldType),
+			contentType: echo.MIMEApplicationJSON,
+		},
+		{
+			name:        "malformed JSON",
+			payload:     []byte(unclosedBracket),
+			contentType: echo.MIMEApplicationJSON,
+		},
+		{
+			name:    "valid JSON with no MIME type",
+			payload: []byte(validJSON),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			prepare := func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, test.contentType)
+			}
+
+			_, ctx, err := setupRecorder(installEndpoint, test.payload, prepare)
+			require.NoError(t, err)
+
+			err = api.Install(ctx)
+			require.Error(t, err)
+
+			echoErr, ok := err.(*echo.HTTPError)
+			require.True(t, ok)
+
+			require.Equal(t, http.StatusBadRequest, echoErr.Code)
+		})
+	}
+}

--- a/api/install_test.go
+++ b/api/install_test.go
@@ -35,7 +35,7 @@ func TestAPI_FunctionInstall(t *testing.T) {
 	})
 }
 
-func TestAPI_FunctionInstallHandlesErrors(t *testing.T) {
+func TestAPI_FunctionInstall_HandlesErrors(t *testing.T) {
 	t.Run("missing URI and CID", func(t *testing.T) {
 		t.Parallel()
 

--- a/api/result.go
+++ b/api/result.go
@@ -2,16 +2,25 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+
+	"github.com/blocklessnetworking/b7s/models/api/request"
 )
 
 // ExecutionResult implements the REST API endpoint for retrieving the result of a function execution.
 func (a *API) ExecutionResult(ctx echo.Context) error {
 
 	// Get the request ID.
-	requestID := ctx.Param("id")
+	var request request.ExecutionResult
+	err := ctx.Bind(&request)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("could not unpack request: %w", err))
+	}
+
+	requestID := request.ID
 	if requestID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("missing request ID"))
 	}

--- a/api/result_test.go
+++ b/api/result_test.go
@@ -1,0 +1,139 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/api"
+	"github.com/blocklessnetworking/b7s/models/api/request"
+	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestAPI_ExecutionResult(t *testing.T) {
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		api := setupAPI(t)
+
+		req := request.ExecutionResult{
+			ID: mocks.GenericString,
+		}
+
+		rec, ctx, err := setupRecorder(resultEndpoint, req)
+		require.NoError(t, err)
+
+		err = api.ExecutionResult(ctx)
+		require.NoError(t, err)
+
+		var res execute.Result
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+
+		require.Equal(t, mocks.GenericExecutionResult, res)
+	})
+	t.Run("response not found", func(t *testing.T) {
+
+		node := mocks.BaselineNode(t)
+		node.ExecutionResultFunc = func(id string) (execute.Result, bool) {
+			return execute.Result{}, false
+		}
+
+		req := request.ExecutionResult{
+			ID: "dummy-request-id",
+		}
+
+		_, ctx, err := setupRecorder(resultEndpoint, req)
+		require.NoError(t, err)
+
+		api := api.New(mocks.NoopLogger, node)
+		err = api.ExecutionResult(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusNotFound, ctx.Response().Status)
+	})
+}
+
+func TestAPI_ExecutionResultHandlesErrors(t *testing.T) {
+
+	api := setupAPI(t)
+
+	const (
+		emptyIDPayload = `
+		{
+			"id": ""
+		}`
+
+		wrongFieldType = `
+		{
+			"id": 14
+		}`
+
+		unclosedBracket = `
+		{
+			"id": "dummy-id",
+		`
+
+		validJSON = `
+		{
+			"id": "dummy-id"
+		}`
+	)
+
+	tests := []struct {
+		name           string
+		payload        []byte
+		contentType    string
+		expectedStatus int
+	}{
+		{
+			name:           "empty request ID",
+			payload:        []byte(emptyIDPayload),
+			contentType:    echo.MIMEApplicationJSON,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "wrong field type",
+			payload:        []byte(wrongFieldType),
+			contentType:    echo.MIMEApplicationJSON,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "unclosed bracket",
+			payload:        []byte(unclosedBracket),
+			contentType:    echo.MIMEApplicationJSON,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "valid JSON with no MIME type set",
+			payload:        []byte(validJSON),
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			prepare := func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, test.contentType)
+			}
+
+			_, ctx, err := setupRecorder(resultEndpoint, test.payload, prepare)
+			require.NoError(t, err)
+
+			err = api.ExecutionResult(ctx)
+			require.Error(t, err)
+
+			echoErr, ok := err.(*echo.HTTPError)
+			require.True(t, ok)
+
+			require.Equal(t, test.expectedStatus, echoErr.Code)
+		})
+	}
+}

--- a/api/result_test.go
+++ b/api/result_test.go
@@ -59,7 +59,7 @@ func TestAPI_ExecutionResult(t *testing.T) {
 	})
 }
 
-func TestAPI_ExecutionResultHandlesErrors(t *testing.T) {
+func TestAPI_ExecutionResult_HandlesErrors(t *testing.T) {
 
 	api := setupAPI(t)
 

--- a/models/api/request/request.go
+++ b/models/api/request/request.go
@@ -9,6 +9,11 @@ type Execute execute.Request
 
 // InstallFunction describes the payload for the REST API request for function install.
 type InstallFunction struct {
-	CID string `query:"cid"`
-	URI string `query:"uri"`
+	CID string `json:"cid"`
+	URI string `json:"uri"`
+}
+
+// ExecutionResult describes the payload for the REST API request for execution result.
+type ExecutionResult struct {
+	ID string `json:"id"`
 }

--- a/testing/mocks/generic.go
+++ b/testing/mocks/generic.go
@@ -33,6 +33,17 @@ var (
 		RequestID: GenericUUID.String(),
 	}
 
+	GenericExecutionRequest = execute.Request{
+		FunctionID: "generic-function-id",
+		Method:     "wasm",
+		Parameters: []execute.Parameter{
+			{
+				Name:  "generic-param-name",
+				Value: "generic-param-value",
+			},
+		},
+	}
+
 	GenericManifest = blockless.FunctionManifest{
 		ID:          "generic-id",
 		Name:        "generic-name",

--- a/testing/mocks/node.go
+++ b/testing/mocks/node.go
@@ -1,0 +1,45 @@
+package mocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+// Node implements the `Node` interface expected by the API.
+type Node struct {
+	ExecuteFunctionFunc func(context.Context, execute.Request) (execute.Result, error)
+	ExecutionResultFunc func(id string) (execute.Result, bool)
+	FunctionInstallFunc func(ctx context.Context, uri string, cid string) error
+}
+
+func BaselineNode(t *testing.T) *Node {
+	t.Helper()
+
+	node := Node{
+		ExecuteFunctionFunc: func(context.Context, execute.Request) (execute.Result, error) {
+			return GenericExecutionResult, nil
+		},
+		ExecutionResultFunc: func(id string) (execute.Result, bool) {
+			return GenericExecutionResult, true
+		},
+		FunctionInstallFunc: func(ctx context.Context, uri string, cid string) error {
+			return nil
+		},
+	}
+
+	return &node
+}
+
+func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request) (execute.Result, error) {
+	return n.ExecuteFunctionFunc(ctx, req)
+}
+
+func (n *Node) ExecutionResult(id string) (execute.Result, bool) {
+	return n.ExecutionResultFunc(id)
+}
+
+func (n *Node) FunctionInstall(ctx context.Context, uri string, cid string) error {
+	return n.FunctionInstallFunc(ctx, uri, cid)
+}


### PR DESCRIPTION
@dmikey Inspired by your comment that there's a bug in how the API behaves on function install code path, I figured it was good to add tests to the API package as well, so we don't have any surprises.

This PR adds tests to the API package, with the test coverage for the package now at 97.7%.

Tests typically cover three scenarios:
1. nominal case - everything works as expected
2. error - one of the node methods tasked with doing something failed
3. invalid payload - e.g. malformed JSON