### PR TITLE
Add resource limits for Blockless runtime on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 cmd/node/node
 cmd/keygen/keygen
+cmd/bootstrap-limiter/bootstrap-limiter
 
 dist/
 runtime/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ You can also use Docker to install b7s. See the [Docker documentation](/docker/R
 | runtime     | N/A        | N/A                     | Specifies the runtime address used by the worker node.                                        |
 | dialback-address | N/A        | N/A                     | Specifies the advertised dialback address of the Node.                                   |
 | dialback-port | N/A | N/A | Specifies the advertised dialback port of the Node. |
+| cpu-percentage-limit | N/A | 1.0 | Specifies the amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited. |
+| memory-limit | N/A | N/A | Specifies the memory limit for Blockless Functions, in kB. |
 
 ## Dependencies
 

--- a/cmd/bootstrap-limiter/README.md
+++ b/cmd/bootstrap-limiter/README.md
@@ -1,0 +1,28 @@
+# Bootstrap Limiter
+
+## Description
+
+This utility is aimed to provide an easy way to setup the system so that a non-privileged user can set resource limits for Blockless Functions.
+This tool is designed to be run a single time, before runing the Blockless Worker Node.
+If the user has no intention of using cgroups to set resource limits, there is no need in running this tool.
+
+## Workaround
+
+This tool aims to provide an easy way to manage the _typical_ use-case.
+It is not mandatory to use the tool to setup your system.
+
+If you would like to setup your system manually, the steps are listed below.
+The readme assumes your `cgroup` mountpoint is the default - `/sys/fs/cgroup`.
+
+    1. Create a directory `/sys/fs/cgroup/blockless`
+    2. Change owner of the directory and its subdirectories to the user that will be running the node. Example: `sudo chown -R <user> /sys/fs/cgroup/blockless`.
+    3. Set files `/sys/fs/cgroup/cgroup.procs` and `/sys/fs/cgroup/cgroup.subtree_control` to be group writable. Example: `sudo chmod 0664 /sys/fs/cgroup/cgroup.procs` (same for `cgroup.subtree_control`)
+    4. Add user to the group that owns the files listed in step 3. By default this would be `root`, so for example `sudo usermod -a -G root <user>`.
+
+## Removing Cgroup
+
+You can remove a cgroup, effectively reverting the changes done by the tool by running `sudo rmdir /sys/fs/cgroup/blockless`.
+
+## Further Reading
+
+To read more about resource limits see [here](https://docs.kernel.org/admin-guide/cgroup-v2.html).

--- a/cmd/bootstrap-limiter/main.go
+++ b/cmd/bootstrap-limiter/main.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/blocklessnetworking/b7s/executor/limits"
 	"github.com/fatih/color"
+	"github.com/spf13/pflag"
+
+	"github.com/blocklessnetworking/b7s/executor/limits"
 )
 
 const (
@@ -40,6 +42,14 @@ func main() {
 
 func run() int {
 
+	var (
+		flagForce bool
+	)
+
+	pflag.BoolVarP(&flagForce, "force", "f", false, "set resource limits without asking for confirmation")
+
+	pflag.Parse()
+
 	log.Default().SetFlags(0)
 
 	// We'll only target linux, though potentially cgroups may exist on some other systems.
@@ -48,7 +58,8 @@ func run() int {
 		return failure
 	}
 
-	if !haveConsent() {
+	// If `--force` was not set - ask for user confirmation before continuing.
+	if !flagForce && !haveConsent() {
 		return failure
 	}
 

--- a/cmd/bootstrap-limiter/main.go
+++ b/cmd/bootstrap-limiter/main.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/blocklessnetworking/b7s/executor/limits"
+	"github.com/fatih/color"
+)
+
+const (
+	success = 0
+	failure = 1
+
+	// SUDO_USER - Set to the login name of the user who invoked sudo.
+	// https://man7.org/linux/man-pages/man8/sudo.8.html
+	sudoUserEnv = "SUDO_USER"
+
+	rootCgroupFilePermissions = 0664
+)
+
+var (
+	requiredFileNames = []string{
+		"cgroup.procs",
+		"cgroup.subtree_control",
+	}
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+
+	log.Default().SetFlags(0)
+
+	// We'll only target linux, though potentially cgroups may exist on some other systems.
+	if runtime.GOOS != "linux" {
+		log.Printf("OS not supported")
+		return failure
+	}
+
+	if !haveConsent() {
+		return failure
+	}
+
+	mountpoint := limits.DefaultMountpoint
+	cgroupName := limits.DefaultCgroup
+
+	currentUser, err := user.Current()
+	if err != nil {
+		log.Printf("could not get current user: %s", err)
+		return failure
+	}
+
+	log.Printf("running as user: %v (uid: %v)", currentUser.Username, currentUser.Uid)
+
+	// The owner-to-be of the cgroup directory.
+	runningUser := os.Getenv(sudoUserEnv)
+	if runningUser == "" {
+		log.Printf("could not get user running sudo - trying with current user")
+		runningUser = currentUser.Username
+	} else {
+		log.Printf("ownership for cgroup will be assigned to user '%v'", runningUser)
+	}
+
+	// Create directory on the default cgroup mountpoint.
+	target := filepath.Join(mountpoint, cgroupName)
+	err = os.MkdirAll(target, 0755)
+	if err != nil {
+		log.Printf("could not create directory: '%v': %s", target, err)
+		return failure
+	}
+
+	log.Printf("cgroup %v created", cgroupName)
+
+	runningUserInfo, err := user.Lookup(runningUser)
+	if err != nil {
+		log.Printf("could not lookup user ID: %s", err)
+		return failure
+	}
+
+	// Convert ID to integer.
+	id, err := strconv.ParseInt(runningUserInfo.Uid, 10, 32)
+	if err != nil {
+		log.Printf("could not parse user UID: %s", err)
+		return failure
+	}
+
+	// Chown directory to be owned by the original user runing sudo.
+	err = chownRecursive(target, int(id), -1)
+	if err != nil {
+		log.Printf("could not set owner for the cgroup: %s", err)
+		return failure
+	}
+
+	log.Printf("access to cgroup %v granted to user '%v'", cgroupName, runningUser)
+
+	var requiredFiles []string
+	for _, name := range requiredFileNames {
+		path := filepath.Join(mountpoint, name)
+		requiredFiles = append(requiredFiles, path)
+	}
+
+	fileGroup := -1
+	// Set permissions for required files.
+	for _, file := range requiredFiles {
+
+		// Make sure group has write permissions.
+		err = os.Chmod(file, rootCgroupFilePermissions)
+		if err != nil {
+			log.Printf("could not set permissions to group writable for %v", file)
+			return failure
+		}
+
+		log.Printf("set file permissions for %v to be group writable", file)
+
+		// Get groupID if not already.
+		if fileGroup == -1 {
+			info, err := os.Stat(file)
+			if err != nil {
+				log.Printf("could not stat file: %v: %s", file, err)
+				continue
+			}
+
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok {
+				log.Printf("unexpected format for stat")
+				continue
+			}
+
+			fileGroup = int(stat.Gid)
+		}
+	}
+
+	group, _ := user.LookupGroupId(fmt.Sprint(fileGroup))
+
+	// If we don't know which group it is, print a generic message.
+	if group == nil {
+		fileList := strings.Join(requiredFiles, ", ")
+		color.Red("please ensure user '%v' is a member of a group with write acess to files %s", runningUser, fileList)
+		return success
+	}
+
+	// Get group name for gid.
+	color.Red("please ensure user '%v' is a member of '%v' group in order to be able to set resource limits for Blockless Functions\n", runningUser, group.Name)
+	color.Red("e.g. by running sudo usermod -a -G <group> <user>")
+
+	return success
+}
+
+func haveConsent() bool {
+
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Printf("This command will attempt to setup the system to set resource limits for Blockless Functions. Would you like to continue? [yes/no]: ")
+
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	return (answer == "yes" || answer == "y")
+}
+
+func chownRecursive(path string, uid int, gid int) error {
+	return filepath.Walk(path, func(name string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		return os.Chown(name, uid, gid)
+	})
+}

--- a/cmd/node/README.md
+++ b/cmd/node/README.md
@@ -21,17 +21,21 @@ Head Nodes also serve a REST API that can be used to query or trigger certain ac
 
 ```console
 Usage of node:
-  -a, --address string       address that the libp2p host will use (default "0.0.0.0")
-      --boot-nodes strings   list of addresses that this node will connect to on startup, in multiaddr format
-  -c, --concurrency uint     maximum number of requests node will process in parallel (default 10)
-  -d, --db string            path to the database used for persisting node data (default "db")
-  -l, --log-level string     log level to use (default "info")
-  -p, --port uint            port that the libp2p host will use
-      --private-key string   private key that the libp2p host will use
-      --rest-api string      address where the head node REST API will listen on
-  -r, --role string          role this note will have in the Blockless protocol (head or worker) (default "worker")
-      --runtime string       runtime address (used by the worker node)
-      --workspace string     directory that the node can use for file storage (default "./workspace")
+  -l, --log-level string             log level to use (default "info")
+  -d, --db string                    path to the database used for persisting node data (default "db")
+  -r, --role string                  role this note will have in the Blockless protocol (head or worker) (default "worker")
+  -a, --address string               address that the b7s host will use (default "0.0.0.0")
+  -p, --port uint                    port that the b7s host will use
+      --dialback-address string      external address that the b7s host will advertise (default "0.0.0.0")
+      --dialback-port uint           external port that the b7s host will advertise
+      --private-key string           private key that the b7s host will use
+  -c, --concurrency uint             maximum number of requests node will process in parallel (default 10)
+      --rest-api string              address where the head node REST API will listen on
+      --boot-nodes strings           list of addresses that this node will connect to on startup, in multiaddr format
+      --workspace string             directory that the node can use for file storage (default "./workspace")
+      --runtime string               runtime address (used by the worker node)
+      --cpu-percentage-limit float   amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited (default 1)
+      --memory-limit int             memory limit (kB) for Blockless Functions
 ```
 
 You can find more information about `multiaddr` format for network addresses [here](https://github.com/multiformats/multiaddr) and [here](https://multiformats.io/multiaddr/).

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -40,6 +40,9 @@ func parseFlags() *config.Config {
 	pflag.StringVar(&cfg.Workspace, "workspace", "./workspace", "directory that the node can use for file storage")
 	pflag.StringVar(&cfg.Runtime, "runtime", "", "runtime address (used by the worker node)")
 
+	pflag.DurationVar(&cfg.CPUTime, "cpu-time-limit", 0, "time limit for CPU time for Blockless function execution")
+	pflag.Int64Var(&cfg.MemoryMaxKB, "memory-limit", 0, "memory limit (kB) for Blockless function execution")
+
 	pflag.Parse()
 
 	return &cfg

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -40,8 +40,10 @@ func parseFlags() *config.Config {
 	pflag.StringVar(&cfg.Workspace, "workspace", "./workspace", "directory that the node can use for file storage")
 	pflag.StringVar(&cfg.Runtime, "runtime", "", "runtime address (used by the worker node)")
 
-	pflag.Float64Var(&cfg.CPUPercentage, "cpu-percentage-limit", 1.0, "percentage of CPU speed allowed for Blockless Functions")
+	pflag.Float64Var(&cfg.CPUPercentage, "cpu-percentage-limit", 1.0, "amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited")
 	pflag.Int64Var(&cfg.MemoryMaxKB, "memory-limit", 0, "memory limit (kB) for Blockless Functions")
+
+	pflag.CommandLine.SortFlags = false
 
 	pflag.Parse()
 

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -40,8 +40,8 @@ func parseFlags() *config.Config {
 	pflag.StringVar(&cfg.Workspace, "workspace", "./workspace", "directory that the node can use for file storage")
 	pflag.StringVar(&cfg.Runtime, "runtime", "", "runtime address (used by the worker node)")
 
-	pflag.DurationVar(&cfg.CPUTime, "cpu-time-limit", 0, "time limit for CPU time for Blockless function execution")
-	pflag.Int64Var(&cfg.MemoryMaxKB, "memory-limit", 0, "memory limit (kB) for Blockless function execution")
+	pflag.Float64Var(&cfg.CPUPercentage, "cpu-percentage-limit", 1.0, "percentage of CPU speed allowed for Blockless Functions")
+	pflag.Int64Var(&cfg.MemoryMaxKB, "memory-limit", 0, "memory limit (kB) for Blockless Functions")
 
 	pflag.Parse()
 

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -119,13 +119,10 @@ func run() int {
 	// If this is a worker node, initialize an executor.
 	if role == blockless.WorkerNode {
 
-		executable := blockless.RuntimeCLI()
-
-		// Crete an executor.
+		// Create an executor.
 		executor, err := executor.New(log,
 			executor.WithWorkDir(cfg.Workspace),
 			executor.WithRuntimeDir(cfg.Runtime),
-			executor.WithExecutableName(executable),
 		)
 		if err != nil {
 			log.Error().

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -119,10 +119,13 @@ func run() int {
 	// If this is a worker node, initialize an executor.
 	if role == blockless.WorkerNode {
 
-		// Create an executor.
+		executable := blockless.RuntimeCLI()
+
+		// Crete an executor.
 		executor, err := executor.New(log,
 			executor.WithWorkDir(cfg.Workspace),
 			executor.WithRuntimeDir(cfg.Runtime),
+			executor.WithExecutableName(executable),
 		)
 		if err != nil {
 			log.Error().

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -130,9 +130,16 @@ func run() int {
 		if needLimiter(cfg) {
 			limiter, err := limits.New(limits.WithCPUPercentage(cfg.CPUPercentage), limits.WithMemoryKB(cfg.MemoryMaxKB))
 			if err != nil {
-				log.Error().Err(err).Msg("could not create resurce limiter")
+				log.Error().Err(err).Msg("could not create resource limiter")
 				return failure
 			}
+
+			defer func() {
+				err = limiter.RemoveAllLimits()
+				if err != nil {
+					log.Error().Err(err).Msg("could not remove resource limtis")
+				}
+			}()
 
 			execOptions = append(execOptions, executor.WithLimiter(limiter))
 		}

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -128,17 +128,11 @@ func run() int {
 		}
 
 		if needLimiter(cfg) {
-			limiter, err := limits.New(limits.WithCPULimit(cfg.CPUTime), limits.WithMemoryKB(cfg.MemoryMaxKB))
+			limiter, err := limits.New(limits.WithCPUPercentage(cfg.CPUPercentage), limits.WithMemoryKB(cfg.MemoryMaxKB))
 			if err != nil {
 				log.Error().Err(err).Msg("could not create resurce limiter")
 				return failure
 			}
-			defer func() {
-				err := limiter.Remove()
-				if err != nil {
-					log.Error().Err(err).Msg("could not remove resource limiter")
-				}
-			}()
 
 			execOptions = append(execOptions, executor.WithLimiter(limiter))
 		}
@@ -255,5 +249,5 @@ func run() int {
 }
 
 func needLimiter(cfg *config.Config) bool {
-	return cfg.CPUTime > 0 || cfg.MemoryMaxKB > 0
+	return cfg.CPUPercentage != 1.0 || cfg.MemoryMaxKB > 0
 }

--- a/config/model.go
+++ b/config/model.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"time"
+)
+
 // Config describes the Blockless configuration options.
 type Config struct {
 	Log          Log
@@ -11,6 +15,9 @@ type Config struct {
 	Host    Host
 	API     string
 	Runtime string
+
+	CPUTime     time.Duration
+	MemoryMaxKB int64
 
 	Workspace string
 }

--- a/config/model.go
+++ b/config/model.go
@@ -1,9 +1,5 @@
 package config
 
-import (
-	"time"
-)
-
 // Config describes the Blockless configuration options.
 type Config struct {
 	Log          Log
@@ -16,8 +12,8 @@ type Config struct {
 	API     string
 	Runtime string
 
-	CPUTime     time.Duration
-	MemoryMaxKB int64
+	CPUPercentage float64
+	MemoryMaxKB   int64
 
 	Workspace string
 }

--- a/executor/command_internal_test.go
+++ b/executor/command_internal_test.go
@@ -20,11 +20,7 @@ func TestExecute_CreateCMD(t *testing.T) {
 		functionID     = "function-id"
 		functionMethod = "function-method"
 
-<<<<<<< HEAD
 		executablePath = filepath.Join(runtimeDir, blockless.RuntimeCLI())
-=======
-		executablePath = filepath.Join(runtimeDir, blockless.RuntimeCLI)
->>>>>>> 6110937 (Runtime CLI name fixed on Windows)
 
 		requestID   = mocks.GenericUUID.String()
 		stdin       = "dummy stdin payload"

--- a/executor/command_internal_test.go
+++ b/executor/command_internal_test.go
@@ -20,7 +20,11 @@ func TestExecute_CreateCMD(t *testing.T) {
 		functionID     = "function-id"
 		functionMethod = "function-method"
 
+<<<<<<< HEAD
 		executablePath = filepath.Join(runtimeDir, blockless.RuntimeCLI())
+=======
+		executablePath = filepath.Join(runtimeDir, blockless.RuntimeCLI)
+>>>>>>> 6110937 (Runtime CLI name fixed on Windows)
 
 		requestID   = mocks.GenericUUID.String()
 		stdin       = "dummy stdin payload"

--- a/executor/config.go
+++ b/executor/config.go
@@ -12,6 +12,7 @@ var defaultConfig = Config{
 	RuntimeDir:     "",
 	ExecutableName: blockless.RuntimeCLI(),
 	FS:             afero.NewOsFs(),
+	Limiter:        &noopLimiter{},
 }
 
 // Config represents the Executor configuration.
@@ -20,6 +21,7 @@ type Config struct {
 	RuntimeDir     string   // directory where the executable can be found
 	ExecutableName string   // name for the executable
 	FS             afero.Fs // FS accessor
+	Limiter        Limiter  // Resource limiter for executed processes
 }
 
 type Option func(*Config)
@@ -49,5 +51,12 @@ func WithFS(fs afero.Fs) Option {
 func WithExecutableName(name string) Option {
 	return func(cfg *Config) {
 		cfg.ExecutableName = name
+	}
+}
+
+// WithLimiter sets the resource limiter called for each individual execution.
+func WithLimiter(limiter Limiter) Option {
+	return func(cfg *Config) {
+		cfg.Limiter = limiter
 	}
 }

--- a/executor/execute_ux.go
+++ b/executor/execute_ux.go
@@ -29,7 +29,7 @@ func (e *Executor) executeCommand(cmd *exec.Cmd) (string, execute.Usage, error) 
 	// Set resource limits on the process.
 	e.log.Debug().Int("pid", cmd.Process.Pid).Msg("setting resource limits for process")
 
-	err = e.cfg.Limiter.LimitProcess(uint64(cmd.Process.Pid))
+	err = e.cfg.Limiter.LimitProcess(cmd.Process.Pid)
 	if err != nil {
 		return "", execute.Usage{}, fmt.Errorf("could not limit process: %w", err)
 	}

--- a/executor/execute_ux.go
+++ b/executor/execute_ux.go
@@ -26,6 +26,16 @@ func (e *Executor) executeCommand(cmd *exec.Cmd) (string, execute.Usage, error) 
 		return "", execute.Usage{}, fmt.Errorf("could not start process: %w", err)
 	}
 
+	// Set resource limits on the process.
+	e.log.Debug().Int("pid", cmd.Process.Pid).Msg("setting resource limits for process")
+
+	err = e.cfg.Limiter.LimitProcess(uint64(cmd.Process.Pid))
+	if err != nil {
+		return "", execute.Usage{}, fmt.Errorf("could not limit process: %w", err)
+	}
+
+	e.log.Debug().Int("pid", cmd.Process.Pid).Msg("resource limits set for process")
+
 	err = cmd.Wait()
 	if err != nil {
 		return "", execute.Usage{}, fmt.Errorf("could not wait on process: %w", err)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -7,6 +7,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// TODO: Currently we may have parallel execution of Blockless functions - e.g. we have two requests at the same time.
+// Do we want to limit this too?
+
+// TODO: Use the provided limiter.
+
 // Executor provides the capabilities to run external applications.
 type Executor struct {
 	log zerolog.Logger

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -10,8 +10,6 @@ import (
 // TODO: Currently we may have parallel execution of Blockless functions - e.g. we have two requests at the same time.
 // Do we want to limit this too?
 
-// TODO: Use the provided limiter.
-
 // Executor provides the capabilities to run external applications.
 type Executor struct {
 	log zerolog.Logger

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -16,6 +16,7 @@ import (
 func TestExecutor_Create(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 
+		// TODO: Fix this test as it assumes CLI is installed.
 		var (
 			runtimeDir = os.TempDir()
 			cliPath    = filepath.Join(runtimeDir, blockless.RuntimeCLI())

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -16,7 +16,6 @@ import (
 func TestExecutor_Create(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 
-		// TODO: Fix this test as it assumes CLI is installed.
 		var (
 			runtimeDir = os.TempDir()
 			cliPath    = filepath.Join(runtimeDir, blockless.RuntimeCLI())

--- a/executor/limiter.go
+++ b/executor/limiter.go
@@ -3,6 +3,10 @@ package executor
 // noopLimiter is a dummy limiter used when processes run without any resource limitations.
 type noopLimiter struct{}
 
-func (n *noopLimiter) LimitProcess(pid uint64) error {
+func (n *noopLimiter) LimitProcess(pid int) error {
 	return nil
+}
+
+func (n *noopLimiter) ListProcesses() ([]int, error) {
+	return []int{}, nil
 }

--- a/executor/limiter.go
+++ b/executor/limiter.go
@@ -3,6 +3,6 @@ package executor
 // noopLimiter is a dummy limiter used when processes run without any resource limitations.
 type noopLimiter struct{}
 
-func (n *noopLimiter) LimitProcess(pid int) error {
+func (n *noopLimiter) LimitProcess(pid uint64) error {
 	return nil
 }

--- a/executor/limiter.go
+++ b/executor/limiter.go
@@ -1,0 +1,8 @@
+package executor
+
+// noopLimiter is a dummy limiter used when processes run without any resource limitations.
+type noopLimiter struct{}
+
+func (n *noopLimiter) LimitProcess(pid int) error {
+	return nil
+}

--- a/executor/limits.go
+++ b/executor/limits.go
@@ -1,5 +1,5 @@
 package executor
 
 type Limiter interface {
-	LimitProcess(pid int) error
+	LimitProcess(pid uint64) error
 }

--- a/executor/limits.go
+++ b/executor/limits.go
@@ -1,0 +1,5 @@
+package executor
+
+type Limiter interface {
+	LimitProcess(pid int) error
+}

--- a/executor/limits.go
+++ b/executor/limits.go
@@ -1,5 +1,6 @@
 package executor
 
 type Limiter interface {
-	LimitProcess(pid uint64) error
+	LimitProcess(pid int) error
+	ListProcesses() ([]int, error)
 }

--- a/executor/limits/config.go
+++ b/executor/limits/config.go
@@ -1,21 +1,17 @@
 package limits
 
-import (
-	"time"
-)
-
 // DefaultConfig describes the default process resource limits.
 var DefaultConfig = Config{
-	Cgroup:   DefaultCgroup,
-	MemoryKB: -1,
-	CPUTime:  time.Duration(-1),
+	Cgroup:        DefaultCgroup,
+	MemoryKB:      -1,
+	CPUPercentage: DefaultCPUPercentage,
 }
 
 // Config represents the resource limits to set.
 type Config struct {
-	Cgroup   string        // Cgroup to use for limits.
-	MemoryKB int64         // Maximum amount of memory allowed in kilobytes.
-	CPUTime  time.Duration // Total CPU time allowed.
+	Cgroup        string  // Cgroup to use for limits.
+	MemoryKB      int64   // Maximum amount of memory allowed in kilobytes.
+	CPUPercentage float64 // Percentage of the CPU time allowed.
 }
 
 // Option can be used to set limits.
@@ -28,10 +24,10 @@ func WithCgroup(path string) Option {
 	}
 }
 
-// WithCPULimit sets the total CPU time allowed.
-func WithCPULimit(d time.Duration) Option {
+// WithCPUPercentage sets the percentage of CPU time allowed.
+func WithCPUPercentage(p float64) Option {
 	return func(cfg *Config) {
-		cfg.CPUTime = d
+		cfg.CPUPercentage = p
 	}
 }
 

--- a/executor/limits/config.go
+++ b/executor/limits/config.go
@@ -1,0 +1,43 @@
+package limits
+
+import (
+	"time"
+)
+
+// DefaultConfig describes the default process resource limits.
+var DefaultConfig = Config{
+	Cgroup:   DefaultCgroup,
+	MemoryKB: -1,
+	CPUTime:  time.Duration(-1),
+}
+
+// Config represents the resource limits to set.
+type Config struct {
+	Cgroup   string        // Cgroup to use for limits.
+	MemoryKB int64         // Maximum amount of memory allowed in kilobytes.
+	CPUTime  time.Duration // Total CPU time allowed.
+}
+
+// Option can be used to set limits.
+type Option func(*Config)
+
+// WithCgroup sets the path for the cgroup used for the jobs.
+func WithCgroup(path string) Option {
+	return func(cfg *Config) {
+		cfg.Cgroup = path
+	}
+}
+
+// WithCPULimit sets the total CPU time allowed.
+func WithCPULimit(d time.Duration) Option {
+	return func(cfg *Config) {
+		cfg.CPUTime = d
+	}
+}
+
+// WithMemoryKB sets the max amount of memory allowed in kilobytes.
+func WithMemoryKB(limit int64) Option {
+	return func(cfg *Config) {
+		cfg.MemoryKB = limit
+	}
+}

--- a/executor/limits/config_internal_test.go
+++ b/executor/limits/config_internal_test.go
@@ -1,0 +1,43 @@
+package limits
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Cgroup(t *testing.T) {
+
+	const cgroup = "/blockless-test"
+
+	cfg := Config{
+		Cgroup: DefaultCgroup,
+	}
+
+	WithCgroup(cgroup)(&cfg)
+	require.Equal(t, cgroup, cfg.Cgroup)
+}
+
+func TestConfig_WithCPUPercentage(t *testing.T) {
+
+	const pct = 0.7
+
+	cfg := Config{
+		CPUPercentage: 1.0,
+	}
+
+	WithCPUPercentage(pct)(&cfg)
+	require.Equal(t, pct, cfg.CPUPercentage)
+}
+
+func TestConfig_WithMemoryKB(t *testing.T) {
+
+	const limit = int64(200_000)
+
+	cfg := Config{
+		MemoryKB: 10,
+	}
+
+	WithMemoryKB(limit)(&cfg)
+	require.Equal(t, limit, cfg.MemoryKB)
+}

--- a/executor/limits/limits.go
+++ b/executor/limits/limits.go
@@ -8,11 +8,6 @@ import (
 	"github.com/containerd/cgroups/v3/cgroup2"
 )
 
-// TODO: Perhaps we crashed and we didn't manage to clean up the cgroup from a previous run.
-// Add a cfg flag to override existing cgroup (and overwrite it).
-
-// TODO: Potentially update the cgroup.
-
 // TODO: For now Linux is fine, but try to think cross-platform when it comes to naming, comments etc.
 
 // TODO: Add support for cgroups v1 - determine on the fly which version to use
@@ -40,14 +35,9 @@ func New(opts ...Option) (*Limits, error) {
 		opt(&cfg)
 	}
 
-	// Cgroup should not exist right now.
-	// _, err := cgroup2.LoadSystemd(cfg.Cgroup, cfg.Cgroup)
-	// if err == nil {
-	// 	return nil, errors.New("cgroup already exists - is there another node instance running?")
-	// }
-
 	specs := cfg.cgroupV2Resources()
-	cg, err := cgroup2.NewSystemd(cfg.Cgroup, cfg.Cgroup, -1, specs)
+
+	cg, err := cgroup2.NewManager(DefaultMountpoint, cfg.Cgroup, specs)
 	if err != nil {
 		return nil, fmt.Errorf("could not create cgroup: %w", err)
 	}
@@ -66,16 +56,6 @@ func (l *Limits) LimitProcess(pid uint64) error {
 	err := l.cgroup.AddProc(pid)
 	if err != nil {
 		return fmt.Errorf("could not set resouce limit for the process: %w", err)
-	}
-
-	return nil
-}
-
-// Remove removes the created resource limit.
-func (l *Limits) Remove() error {
-	err := l.cgroup.Delete()
-	if err != nil {
-		return fmt.Errorf("could not remove resource limits: %w", err)
 	}
 
 	return nil

--- a/executor/limits/limits.go
+++ b/executor/limits/limits.go
@@ -11,7 +11,6 @@ import (
 )
 
 // TODO: Add support for cgroups v1 - determine on the fly which version to use
-// TODO: Return a value saying if limiting is supported at all
 
 type Limits struct {
 	cfg Config
@@ -87,8 +86,6 @@ func (l *Limits) RemoveAllLimits() error {
 	period := uint64(time.Second.Microseconds())
 	memLimit := int64(math.MaxInt64)
 
-	// TODO: Just write your own code to write `max` and `max 1000000` (or whatever)
-
 	resources := cgroup2.Resources{
 		CPU: &cgroup2.CPU{
 			Max: cgroup2.NewCPUMax(nil, &period),
@@ -105,25 +102,3 @@ func (l *Limits) RemoveAllLimits() error {
 
 	return nil
 }
-
-// RemoveAllLimits will remove any set resource limits.
-// NOTE: Does not work since the library tries to also update the root `cgroup.subtree_control` - which it shouldn't
-// func (l *Limits) RemoveAllLimits() error {
-//
-// 	controllers, err := l.cgroup.Controllers()
-// 	if err != nil {
-// 		return fmt.Errorf("could not get controllers: %w", err)
-// 	}
-//
-// 	for _, c := range controllers {
-// 		fmt.Printf("%s\n", c)
-// 	}
-//
-// 	err = l.cgroup.ToggleControllers(controllers, cgroup2.Disable)
-// 	if err != nil {
-// 		return fmt.Errorf("could not disable controllers: %w", err)
-// 	}
-//
-// 	return nil
-// }
-//

--- a/executor/limits/limits.go
+++ b/executor/limits/limits.go
@@ -51,12 +51,28 @@ func New(opts ...Option) (*Limits, error) {
 }
 
 // LimitProcess will set the resource limits for the process with the given PID.
-func (l *Limits) LimitProcess(pid uint64) error {
+func (l *Limits) LimitProcess(pid int) error {
 
-	err := l.cgroup.AddProc(pid)
+	err := l.cgroup.AddProc(uint64(pid))
 	if err != nil {
-		return fmt.Errorf("could not set resouce limit for the process: %w", err)
+		return fmt.Errorf("could not set resouce limit for process (pid: %v): %w", pid, err)
 	}
 
 	return nil
+}
+
+// ListProcesses will return the pids of the processes that were added to the resource limit group.
+func (l *Limits) ListProcesses() ([]int, error) {
+
+	var list []int
+	pids, err := l.cgroup.Procs(false)
+	if err != nil {
+		return nil, fmt.Errorf("could not get list of limited processes: %w", err)
+	}
+
+	for _, pid := range pids {
+		list = append(list, int(pid))
+	}
+
+	return list, nil
 }

--- a/executor/limits/limits.go
+++ b/executor/limits/limits.go
@@ -1,0 +1,74 @@
+package limits
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/containerd/cgroups"
+)
+
+// TODO: Perhaps we crashed and we didn't manage to clean up the cgroup from a previous run.
+// Add a cfg flag to override existing cgroup (and overwrite it).
+
+// TODO: Potentially update the cgroup.
+
+// TODO: For now Linux is fine, but try to think cross-platform when it comes to naming, comments etc.
+
+type Limits struct {
+	cfg Config
+
+	cgroup cgroups.Cgroup
+}
+
+// New creates a new process resource limit with the given configuration.
+func New(opts ...Option) (*Limits, error) {
+
+	cfg := DefaultConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Cgroup should not exist right now.
+	_, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(cfg.Cgroup))
+	if err == nil {
+		return nil, errors.New("cgroup already exists - is there another node instance running?")
+	}
+
+	specs := cfg.linuxResources()
+	cg, err := cgroups.New(cgroups.V1, cgroups.StaticPath(cfg.Cgroup), specs)
+	if err != nil {
+		return nil, fmt.Errorf("could not create cgroup: %w", err)
+	}
+
+	l := Limits{
+		cfg:    cfg,
+		cgroup: cg,
+	}
+
+	return &l, nil
+}
+
+// LimitProcess will set the resource limits for the process with the given PID.
+func (l *Limits) LimitProcess(pid int) error {
+
+	proc := cgroups.Process{
+		Pid: pid,
+	}
+
+	err := l.cgroup.Add(proc)
+	if err != nil {
+		return fmt.Errorf("could not set resouce limit for the process: %w", err)
+	}
+
+	return nil
+}
+
+// Remove removes the created resource limit.
+func (l *Limits) Remove() error {
+	err := l.cgroup.Delete()
+	if err != nil {
+		return fmt.Errorf("could not remove resource limits: %w", err)
+	}
+
+	return nil
+}

--- a/executor/limits/limits.go
+++ b/executor/limits/limits.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup2"
 )
 

--- a/executor/limits/limits_integration_test.go
+++ b/executor/limits/limits_integration_test.go
@@ -1,0 +1,131 @@
+//go:build limits
+// +build limits
+
+package limits_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/executor/limits"
+)
+
+const (
+	cpuMaxFile = "cpu.max"
+	memMaxFile = "memory.max"
+	pidFile    = "cgroup.procs"
+)
+
+func TestLimits(t *testing.T) {
+
+	const (
+		cgroup   = limits.DefaultCgroup
+		cpuLimit = 0.95
+		memLimit = 999_424 // ~1GB rounded to typical page size - 4k
+	)
+
+	limiter, err := limits.New(
+		limits.WithCgroup(cgroup),
+		limits.WithCPUPercentage(cpuLimit),
+		limits.WithMemoryKB(memLimit),
+	)
+	require.NoError(t, err)
+
+	// Always remove all resource limits.
+	defer func() {
+		err = limiter.RemoveAllLimits()
+		require.NoError(t, err)
+	}()
+
+	verifyCPULImit(t, cgroup, cpuLimit)
+	verifyMemLimit(t, cgroup, memLimit)
+
+	// Verify list of limited processes is empty.
+	pids, err := limiter.ListProcesses()
+	require.NoError(t, err)
+	require.Empty(t, pids)
+
+	// Put resource limit on self.
+	// This is effectively a limit on go test so we're conservative with limits.
+	pid := os.Getpid()
+	err = limiter.LimitProcess(pid)
+	require.NoError(t, err)
+
+	// Verify list of limited processes now has a single process.
+	pids, err = limiter.ListProcesses()
+	require.NoError(t, err)
+	require.Len(t, pids, 1)
+	require.Equal(t, pids[0], pid)
+
+	// Manually verify the PID limit.
+	verifyPids(t, cgroup, []int{pid})
+}
+
+func verifyCPULImit(t *testing.T, cgroup string, limit float64) {
+
+	path := filepath.Join(limits.DefaultMountpoint, cgroup, cpuMaxFile)
+
+	payload, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	fields := strings.Fields(string(payload))
+	require.Len(t, fields, 2)
+
+	cap, err := strconv.ParseFloat(fields[0], 64)
+	require.NoError(t, err)
+
+	period, err := strconv.ParseFloat(fields[1], 64)
+	require.NoError(t, err)
+
+	quota := cap / period
+	require.Equal(t, limit, quota)
+}
+
+func verifyMemLimit(t *testing.T, cgroup string, limitKB int64) {
+
+	path := filepath.Join(limits.DefaultMountpoint, cgroup, memMaxFile)
+
+	payload, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	read := strings.TrimSpace(string(payload))
+
+	limitBytes := limitKB * 1000
+	expected := fmt.Sprint(limitBytes)
+
+	require.Equal(t, expected, read)
+}
+
+func verifyPids(t *testing.T, cgroup string, pids []int) {
+	path := filepath.Join(limits.DefaultMountpoint, cgroup, pidFile)
+
+	payload, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	lines := strings.Split(string(payload), "\n")
+
+	var readPids []int
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Handle trailing newline
+		if line == "" {
+			continue
+		}
+
+		pid, err := strconv.ParseInt(line, 10, 32)
+		require.NoError(t, err)
+
+		readPids = append(readPids, int(pid))
+	}
+
+	for i, pid := range readPids {
+		require.Equal(t, pid, pids[i])
+	}
+}

--- a/executor/limits/params.go
+++ b/executor/limits/params.go
@@ -1,11 +1,9 @@
 package limits
 
-import (
-	"time"
-)
-
 const (
-	DefaultCgroup = "blockless"
+	DefaultCgroup     = "/blockless"
+	DefaultMountpoint = "/sys/fs/cgroup"
 
-	year = time.Hour * 24 * 365
+	// Default percentage of the CPU allowed. By default we run unlimited.
+	DefaultCPUPercentage = 1.0
 )

--- a/executor/limits/params.go
+++ b/executor/limits/params.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	DefaultCgroup = "/blockless"
+	DefaultCgroup = "blockless"
 
 	year = time.Hour * 24 * 365
 )

--- a/executor/limits/params.go
+++ b/executor/limits/params.go
@@ -1,0 +1,11 @@
+package limits
+
+import (
+	"time"
+)
+
+const (
+	DefaultCgroup = "/blockless"
+
+	year = time.Hour * 24 * 365
+)

--- a/executor/limits/specs.go
+++ b/executor/limits/specs.go
@@ -1,0 +1,36 @@
+package limits
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func (cfg *Config) linuxResources() *specs.LinuxResources {
+
+	lr := specs.LinuxResources{}
+
+	// Set CPU limit, if set.
+	if cfg.CPUTime > 0 {
+
+		// We want to set total CPU time limit. We'll use one year as the period.
+		period := uint64(year.Microseconds())
+		quota := cfg.CPUTime.Microseconds()
+
+		lr.CPU = &specs.LinuxCPU{
+			Period: &period,
+			Quota:  &quota,
+		}
+	}
+
+	// Set memory limit, if set.
+	if cfg.MemoryKB > 0 {
+
+		// Convert limit to bytes.
+		memLimit := cfg.MemoryKB * 1000
+
+		lr.Memory = &specs.LinuxMemory{
+			Limit: &memLimit,
+		}
+	}
+
+	return &lr
+}

--- a/executor/limits/specs.go
+++ b/executor/limits/specs.go
@@ -1,6 +1,8 @@
 package limits
 
 import (
+	"time"
+
 	"github.com/containerd/cgroups/v3/cgroup2"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -9,11 +11,12 @@ func (cfg *Config) linuxResources() *specs.LinuxResources {
 
 	lr := specs.LinuxResources{}
 
-	if cfg.CPUTime > 0 {
+	// Set CPU limit, if set.
+	if cfg.CPUPercentage != 1.0 {
 
 		// We want to set total CPU time limit. We'll use one year as the period.
-		period := uint64(year.Microseconds())
-		quota := cfg.CPUTime.Microseconds()
+		period := uint64(time.Second.Microseconds())
+		quota := int64(float64(period) * float64(cfg.CPUPercentage))
 
 		lr.CPU = &specs.LinuxCPU{
 			Period: &period,

--- a/executor/limits/specs.go
+++ b/executor/limits/specs.go
@@ -1,6 +1,7 @@
 package limits
 
 import (
+	"github.com/containerd/cgroups/v3/cgroup2"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -8,7 +9,6 @@ func (cfg *Config) linuxResources() *specs.LinuxResources {
 
 	lr := specs.LinuxResources{}
 
-	// Set CPU limit, if set.
 	if cfg.CPUTime > 0 {
 
 		// We want to set total CPU time limit. We'll use one year as the period.
@@ -33,4 +33,9 @@ func (cfg *Config) linuxResources() *specs.LinuxResources {
 	}
 
 	return &lr
+}
+
+func (cfg *Config) cgroupV2Resources() *cgroup2.Resources {
+	lr := cfg.linuxResources()
+	return cgroup2.ToResources(lr)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/blocklessnetworking/b7s
 go 1.19
 
 require (
+	github.com/Microsoft/go-winio v0.6.0
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cockroachdb/pebble v0.0.0-20220929203247-18d98601a233
+	github.com/containerd/cgroups/v3 v3.0.1
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/libp2p/go-libp2p v0.26.4
 	github.com/libp2p/go-libp2p-kad-dht v0.21.1
@@ -18,7 +20,7 @@ require (
 )
 
 require (
-	github.com/Microsoft/go-winio v0.6.0 // indirect
+	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -33,6 +35,7 @@ require (
 	github.com/quic-go/qtls-go1-20 v0.1.1 // indirect
 	github.com/quic-go/quic-go v0.33.0 // indirect
 	github.com/quic-go/webtransport-go v0.5.2 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	go.uber.org/dig v1.15.0 // indirect
@@ -54,7 +57,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect
 	github.com/cockroachdb/redact v1.0.8 // indirect
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 // indirect
-	github.com/containerd/cgroups v1.0.4 // indirect
+	github.com/containerd/cgroups v1.1.0
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
@@ -117,7 +120,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
-	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
+	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -141,7 +144,7 @@ require (
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/sys v0.6.0
 	golang.org/x/tools v0.6.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 require (
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.15.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/pprof v0.0.0-20221203041831-ce31453925ec // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
+github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
+github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -97,8 +99,10 @@ github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 h1:IKgmqgMQlVJIZj19CdocBeS
 github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk0R8eg+OTkcqI6baNH4xAkpiYVvQ=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/containerd/cgroups v0.0.0-20201119153540-4cbc285b3327/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
-github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
-github.com/containerd/cgroups v1.0.4/go.mod h1:nLNQtsF7Sl2HxNebu77i1R0oDlhiTG+kO4JTrUzo6IA=
+github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
+github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
+github.com/containerd/cgroups/v3 v3.0.1 h1:4hfGvu8rfGIwVIDd+nLzn/B9ZXx4BcCjzt5ToenJRaE=
+github.com/containerd/cgroups/v3 v3.0.1/go.mod h1:/vtwk1VXrtoa5AaZLkypuOJgA/6DyPMZHJPGQNtlHnw=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -586,6 +590,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYEDaXHZDBsXlPCDqdhQuJkuw4NOtaxYe3xii4=
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/assertions v1.13.0 h1:Dx1kYM01xsSqKPno3aqLnrwac2LetPvN23diwyr69Qs=

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/node/config_internal_test.go
+++ b/node/config_internal_test.go
@@ -15,7 +15,7 @@ func TestConfig_NodeRole(t *testing.T) {
 	const role = blockless.WorkerNode
 
 	cfg := Config{
-		Role: blockless.WorkerNode,
+		Role: blockless.HeadNode,
 	}
 
 	WithRole(role)(&cfg)


### PR DESCRIPTION
This PR introduces the capability to set resource limits on Linux.

## How do we set resource limits

We use cgroups v2 to set resource limits. Operating systems that support cgroups v2 are the following:

- Fedora (since 31)
- Arch Linux (since April 2021)
- openSUSE Tumbleweed (since c. 2021)
- Debian GNU/Linux (since 11)
- Ubuntu (since 21.10, 22.04+ recommended)
- RHEL and RHEL-like distributions (since 9)

We can add support for cgroups v1 too. However, it seemed to me that v2 support is the industry accepted approach. Also, cgroups v1 and v2 might cohabitate on the system, so handling both at the same time _might_ be a little more involved.

### Privileges

By default, cgroup handling requires root access. I don't think it's necessary (or good) for users to run nodes with superuser privileges, so I investigated how is it possible to manage cgroups with a non-root account. It turns out it's possible with a few tasks done before using the limits.

I wrote a simple tool (could have been a shell script) that will prepare the system by creating all the required directories and setting all needed permissions. There is a single step that is left to the user to do - to add the user to the `root` group. This is advised by the command `cmd/bootstrap-limiter/`. Everything done by the command - and instructions for the user to prepare the system by hand - is documented in `cmd/bootstrap-limiter/README.md`.

Note that if the user has no intention to use resource limits, there's no need for anything to be done, everything will work like it has so far.

## Resource limits

We currently support two types of resource limits:

- CPU percentage - how much of the CPU time we want to allocate for the runtime
- Maximum memory allowed - in kilobytes

These limits can be set by using the flags `--cpu-percentage-limit`  and `--memory-limit`. By default we run unlimited.

Note that these resource limits are shared for all instances of the Blockless Runtime started by the node.

## Tests 

Tests are added for the resource limiter, verifying the cgroup files are created with the expected content.
These tests don't run by default, and can be run by using the `go test --tags=limits ./...` command line.
Reason for these tests being disabled by default is the preparation to be done by an account with root access, which isn't the normal case.