### PR TITLE
Limits supported only on linux - don't build other operating systems

### DIFF
--- a/cmd/bootstrap-limiter/main.go
+++ b/cmd/bootstrap-limiter/main.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package main
 
 import (

--- a/executor/limits/limits_gen.go
+++ b/executor/limits/limits_gen.go
@@ -1,0 +1,34 @@
+//go:build !linux
+// +build !linux
+
+package limits
+
+import (
+	"errors"
+)
+
+// NOTE: Placeholder until Windows limits are introduced.
+
+type Limits struct {
+	cfg Config
+}
+
+// New creates a new process resource limit with the given configuration.
+func New(opts ...Option) (*Limits, error) {
+	return nil, errors.New("TBD: not implemented")
+}
+
+// LimitProcess will set the resource limits for the process with the given PID.
+func (l *Limits) LimitProcess(pid int) error {
+	return errors.New("TBD: not implemented")
+}
+
+// ListProcesses will return the pids of the processes that were added to the resource limit group.
+func (l *Limits) ListProcesses() ([]int, error) {
+	return nil, errors.New("TBD: not implemented")
+}
+
+// RemoveAllLimits will remove any set resource limits.
+func (l *Limits) RemoveAllLimits() error {
+	return errors.New("TBD: not implemented")
+}

--- a/executor/limits/limits_linux.go
+++ b/executor/limits/limits_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package limits
 
 import (

--- a/executor/limits/specs_linux.go
+++ b/executor/limits/specs_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package limits
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cockroachdb/pebble v0.0.0-20220929203247-18d98601a233
 	github.com/containerd/cgroups/v3 v3.0.1
+	github.com/fatih/color v1.15.0
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/libp2p/go-libp2p v0.26.4
 	github.com/libp2p/go-libp2p-kad-dht v0.21.1
@@ -22,7 +23,6 @@ require (
 require (
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.15.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/pprof v0.0.0-20221203041831-ce31453925ec // indirect
@@ -58,7 +58,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect
 	github.com/cockroachdb/redact v1.0.8 // indirect
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 // indirect
-	github.com/containerd/cgroups v1.1.0
+	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect


### PR DESCRIPTION
This PR makes changes to fix the build on operating systems not supporting cgroups. For now, the build on other operating systems will build a limiter that returns error upon attempted use.