### PR TITLE
Don't use verbose output for tests on workflow

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run Test
         run: |
-          go test -v ./... -covermode=count -coverprofile=coverage.out
+          go test ./... -covermode=count -coverprofile=coverage.out
           go tool cover -func=coverage.out -o=coverage.out
 
       - name: Go Coverage Badge # Pass the `coverage.out` output to this action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,5 +23,5 @@ jobs:
 
       - name: Run Test
         run: |
-          go test -v ./... -covermode=count -coverprofile=coverage.out
+          go test ./... -covermode=count -coverprofile=coverage.out
           go tool cover -func=coverage.out -o=coverage.out


### PR DESCRIPTION
`Verbose` tag adds a lot of noise to the test output, and without it we still get everything we need - list of errors that happened, if any.