### PR TITLE
Fix directory for function archive

### DIFF
--- a/fstore/http.go
+++ b/fstore/http.go
@@ -34,14 +34,14 @@ func (h *FStore) getJSON(address string, out interface{}) error {
 // download will retrieve the function with the given manifest. It returns the full path
 // of the file where the function is saved on the local storage or any error that might have
 // occurred in the process. The function blocks until the download is complete.
-func (h *FStore) download(manifest blockless.FunctionManifest) (string, error) {
+func (h *FStore) download(cid string, manifest blockless.FunctionManifest) (string, error) {
 
 	// Determine directory where files should be stored.
-	fdir := filepath.Join(h.workdir, manifest.Function.ID)
+	fdir := filepath.Join(h.workdir, cid)
 
 	h.log.Info().
 		Str("target_dir", fdir).
-		Str("function_id", manifest.Function.ID).
+		Str("cid", cid).
 		Str("function_uri", manifest.Deployment.URI).
 		Msg("downloading function")
 
@@ -76,7 +76,7 @@ func (h *FStore) download(manifest blockless.FunctionManifest) (string, error) {
 
 	h.log.Info().
 		Str("output", res.Filename).
-		Str("function_id", manifest.Function.ID).
+		Str("cid", cid).
 		Str("function_uri", manifest.Deployment.URI).
 		Msg("downloaded function")
 

--- a/fstore/http_internal_test.go
+++ b/fstore/http_internal_test.go
@@ -166,7 +166,7 @@ func TestFunction_Download(t *testing.T) {
 		},
 	}
 
-	path, err := fh.download(manifest)
+	path, err := fh.download("", manifest)
 	require.NoError(t, err)
 
 	// Check if the file created is within the specified workdir.
@@ -216,7 +216,7 @@ func TestFunction_DownloadHandlesErrors(t *testing.T) {
 			},
 		}
 
-		_, err = fh.download(manifest)
+		_, err = fh.download("", manifest)
 		require.Error(t, err)
 	})
 	t.Run("handles invalid URI", func(t *testing.T) {
@@ -239,7 +239,7 @@ func TestFunction_DownloadHandlesErrors(t *testing.T) {
 			},
 		}
 
-		_, err = fh.download(manifest)
+		_, err = fh.download("", manifest)
 		require.Error(t, err)
 	})
 	t.Run("handles download failure", func(t *testing.T) {
@@ -264,7 +264,7 @@ func TestFunction_DownloadHandlesErrors(t *testing.T) {
 			},
 		}
 
-		_, err = fh.download(manifest)
+		_, err = fh.download("", manifest)
 		require.Error(t, err)
 	})
 }

--- a/fstore/install.go
+++ b/fstore/install.go
@@ -32,7 +32,7 @@ func (h *FStore) Install(address string, cid string) error {
 	}
 
 	// Download the function identified by the manifest.
-	functionPath, err := h.download(manifest)
+	functionPath, err := h.download(cid, manifest)
 	if err != nil {
 		return fmt.Errorf("could not download function: %w", err)
 	}

--- a/fstore/sync.go
+++ b/fstore/sync.go
@@ -45,7 +45,7 @@ func (h *FStore) Sync(cid string) error {
 
 	// If we don't have the archive - redownload it.
 	if !haveArchive {
-		path, err := h.download(fn.Manifest)
+		path, err := h.download(cid, fn.Manifest)
 		if err != nil {
 			return fmt.Errorf("could not download the function archive (cid: %v): %w", cid, err)
 		}

--- a/node/roll_call.go
+++ b/node/roll_call.go
@@ -43,9 +43,11 @@ func (n *Node) processRollCall(ctx context.Context, from peer.ID, payload []byte
 	installed, err := n.fstore.Installed(req.FunctionID)
 	if err != nil {
 		sendErr := n.send(ctx, req.From, res)
-		// Log send error but choose to return the original error.
-		n.log.Error().Err(sendErr).Str("to", req.From.String()).
-			Msg("could not send response")
+		if sendErr != nil {
+			// Log send error but choose to return the original error.
+			n.log.Error().Err(sendErr).Str("to", req.From.String()).
+				Msg("could not send response")
+		}
 
 		return fmt.Errorf("could not check if function is installed: %w", err)
 	}
@@ -59,9 +61,11 @@ func (n *Node) processRollCall(ctx context.Context, from peer.ID, payload []byte
 		err = n.installFunction(req.FunctionID, manifestURLFromCID(req.FunctionID))
 		if err != nil {
 			sendErr := n.send(ctx, req.From, res)
-			// Log send error but choose to return the original error.
-			n.log.Error().Err(sendErr).Str("to", req.From.String()).
-				Msg("could not send response")
+			if sendErr != nil {
+				// Log send error but choose to return the original error.
+				n.log.Error().Err(sendErr).Str("to", req.From.String()).
+					Msg("could not send response")
+			}
 
 			return fmt.Errorf("could not install function: %w", err)
 		}


### PR DESCRIPTION
This PR fixes the path for downloaded function archive. Previously we relied on the manifest for that info, and it can be empty.

This lead to the output file conflicts since all `.tar.gz` files were stored flatly in the workspace, causing name collisions. This also lead to download issues when our download library tried to check the file size for (potential) resumed downloads.