### PR TITLE
Improve peerstore implementation

### DIFF
--- a/models/blockless/peer.go
+++ b/models/blockless/peer.go
@@ -6,7 +6,6 @@ import (
 
 // Peer identifies another node in the Blockless network.
 type Peer struct {
-	Type      string        `json:"type,omitempty"`
 	ID        peer.ID       `json:"id,omitempty"`
 	MultiAddr string        `json:"multiaddress,omitempty"`
 	AddrInfo  peer.AddrInfo `json:"addrinfo,omitempty"`

--- a/node/notifiee.go
+++ b/node/notifiee.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// TODO: Potentially move to internal package.
 type connectionNotifiee struct {
 	log   zerolog.Logger
 	peers PeerStore
@@ -30,7 +29,7 @@ func (n *connectionNotifiee) Connected(network network.Network, conn network.Con
 	addrInfo := network.Peerstore().PeerInfo(peerID)
 
 	n.log.Debug().
-		Str("id", peerID.String()).
+		Str("peer", peerID.String()).
 		Str("addr", maddr.String()).
 		Msg("peer connected")
 
@@ -39,22 +38,22 @@ func (n *connectionNotifiee) Connected(network network.Network, conn network.Con
 	if err != nil {
 		n.log.Warn().Err(err).Str("id", peerID.String()).Msg("could not add peer to peerstore")
 	}
-
-	// Update peer list.
-	err = n.peers.UpdatePeerList(peerID, maddr, addrInfo)
-	if err != nil {
-		n.log.Warn().Err(err).Str("id", peerID.String()).Msg("could not update peers in peerstore")
-	}
 }
 
-func (n *connectionNotifiee) Disconnected(_ network.Network, _ network.Conn) {
-	// TBD: Not implemented
+func (n *connectionNotifiee) Disconnected(_ network.Network, conn network.Conn) {
+
+	// TODO: Check - do we want to remove peer after he's been disconnected.
+
+	peerID := conn.RemotePeer()
+	n.log.Debug().
+		Str("peer", peerID.String()).
+		Msg("peer disconnected")
 }
 
 func (n *connectionNotifiee) Listen(_ network.Network, _ multiaddr.Multiaddr) {
-	// TBD: Not implemented
+	// Noop
 }
 
 func (n *connectionNotifiee) ListenClose(_ network.Network, _ multiaddr.Multiaddr) {
-	// TBD: Not implemented
+	// Noop
 }

--- a/node/notifiee_internal_test.go
+++ b/node/notifiee_internal_test.go
@@ -24,18 +24,13 @@ func TestNode_Notifiee(t *testing.T) {
 	require.NoError(t, err)
 
 	var (
-		storedPeer      bool
-		updatedPeerList bool
+		storedPeer bool
 	)
 
 	peerstore := mocks.BaselinePeerStore(t)
 	// Override the peerstore methods so we know if the node correctly handled incoming connection.
 	peerstore.StoreFunc = func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error {
 		storedPeer = true
-		return nil
-	}
-	peerstore.UpdatePeerListFunc = func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error {
-		updatedPeerList = true
 		return nil
 	}
 
@@ -53,5 +48,4 @@ func TestNode_Notifiee(t *testing.T) {
 
 	// Verify that peer store was updated.
 	require.True(t, storedPeer)
-	require.True(t, updatedPeerList)
 }

--- a/node/peerstore.go
+++ b/node/peerstore.go
@@ -7,5 +7,4 @@ import (
 
 type PeerStore interface {
 	Store(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
-	UpdatePeerList(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
 }

--- a/peerstore/params.go
+++ b/peerstore/params.go
@@ -1,5 +1,0 @@
-package peerstore
-
-const (
-	peersKey = "peers"
-)

--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -24,6 +24,18 @@ func New(store Store) *PeerStore {
 	return &ps
 }
 
+// Get wil retrieve peer with the given ID.
+func (p *PeerStore) Get(id peer.ID) (blockless.Peer, error) {
+
+	var peer blockless.Peer
+	err := p.store.GetRecord(id.String(), &peer)
+	if err != nil {
+		return blockless.Peer{}, fmt.Errorf("could not retrieve peer: %w", err)
+	}
+
+	return peer, nil
+}
+
 // Store will persist the peer information.
 func (p *PeerStore) Store(id peer.ID, addr multiaddr.Multiaddr, info peer.AddrInfo) error {
 

--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -1,7 +1,6 @@
 package peerstore
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -26,34 +25,15 @@ func New(store Store) *PeerStore {
 }
 
 // Store will persist the peer information.
-func (p *PeerStore) Store(peerID peer.ID, addr multiaddr.Multiaddr, info peer.AddrInfo) error {
+func (p *PeerStore) Store(id peer.ID, addr multiaddr.Multiaddr, info peer.AddrInfo) error {
 
-	// Check if we already have this peer stored.
-	var peer blockless.Peer
-	err := p.store.GetRecord(peerID.String(), &peer)
-	// If we don't have an error it means that the peer is already stored in the DB. We're done.
-	if err == nil {
-		return nil
-	}
-
-	// Check if we failed to retrieve the record. If the error is `not found` - that's okay,
-	// and we want to store the peer info now. If it's any other error - halt.
-	if err != nil && !errors.Is(err, blockless.ErrNotFound) {
-		return fmt.Errorf("could not retrieve peer: %w", err)
-	}
-
-	// New peer - create peer info record and store it.
 	peerInfo := blockless.Peer{
-		Type:      "peer",
-		ID:        peerID,
+		ID:        id,
 		MultiAddr: addr.String(),
 		AddrInfo:  info,
 	}
 
-	// Store the peer in the DB.
-	// NOTE: This may not be necessary, in case we already had this peer info.
-	// Check if we should re-store this data - perhaps we'd be updating part of it?
-	err = p.store.SetRecord(peerID.String(), peerInfo)
+	err := p.store.SetRecord(id.String(), peerInfo)
 	if err != nil {
 		return fmt.Errorf("could not store peer: %w", err)
 	}
@@ -61,41 +41,12 @@ func (p *PeerStore) Store(peerID peer.ID, addr multiaddr.Multiaddr, info peer.Ad
 	return nil
 }
 
-// UpdatePeerList will check if the specified peer is found in the peer list. If not - it will be added.
-// NOTE: We're basically duplicating knowledge here - if we have peer stored under its ID,
-// we will have it in the `peers` list; do we need to duplicate it?
-func (p *PeerStore) UpdatePeerList(peerID peer.ID, addr multiaddr.Multiaddr, info peer.AddrInfo) error {
+// Remove removes the peer from the peerstore.
+func (p *PeerStore) Remove(id peer.ID) error {
 
-	// Get list of peers from the store.
-	var peers []blockless.Peer
-	err := p.store.GetRecord(peersKey, &peers)
-	if err != nil && !errors.Is(err, blockless.ErrNotFound) {
-		return fmt.Errorf("could not retrieve peer list: %w", err)
-	}
-
-	// Check if this is a known peer.
-	// NOTE: List iteration, might be slow with a long peer list and frequent connections.
-	for _, peer := range peers {
-
-		// If the peer is already known, we're done.
-		if peer.ID == peerID {
-			return nil
-		}
-	}
-
-	// New peer - add it to the list of peers.
-	peerInfo := blockless.Peer{
-		Type:      "peer",
-		ID:        peerID,
-		MultiAddr: addr.String(),
-		AddrInfo:  info,
-	}
-	peers = append(peers, peerInfo)
-
-	// Store the updated peer list.
-	err = p.store.SetRecord(peersKey, peers)
+	err := p.store.Delete(id.String())
 	if err != nil {
-		return fmt.Errorf("could not update peer list: %w", err)
+		return fmt.Errorf("could not remove peer: %w", err)
 	}
 
 	return nil
@@ -104,11 +55,18 @@ func (p *PeerStore) UpdatePeerList(peerID peer.ID, addr multiaddr.Multiaddr, inf
 // Peers returns the list of peers from the peer store.
 func (p *PeerStore) Peers() ([]blockless.Peer, error) {
 
-	// Get list of peers from the store.
+	ids := p.store.Keys()
+
 	var peers []blockless.Peer
-	err := p.store.GetRecord(peersKey, &peers)
-	if err != nil && !errors.Is(err, blockless.ErrNotFound) {
-		return nil, fmt.Errorf("could not retrieve peer list: %w", err)
+	for _, id := range ids {
+
+		var peer blockless.Peer
+		err := p.store.GetRecord(id, &peer)
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve peer (id: %v): %w", id, err)
+		}
+
+		peers = append(peers, peer)
 	}
 
 	return peers, nil

--- a/peerstore/store.go
+++ b/peerstore/store.go
@@ -3,4 +3,6 @@ package peerstore
 type Store interface {
 	SetRecord(key string, value interface{}) error
 	GetRecord(key string, out interface{}) error
+	Keys() []string
+	Delete(key string) error
 }

--- a/store/delete.go
+++ b/store/delete.go
@@ -1,0 +1,18 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// Delete removes the key from the database.
+func (s *Store) Delete(key string) error {
+
+	err := s.db.Delete([]byte(key), pebble.Sync)
+	if err != nil {
+		return fmt.Errorf("could not delete value: %w", err)
+	}
+
+	return nil
+}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -224,4 +224,27 @@ func Test_Store(t *testing.T) {
 		readKeys := store.Keys()
 		require.Equal(t, keys, readKeys)
 	})
+	t.Run("deleting key", func(t *testing.T) {
+		t.Parallel()
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
+		store := store.New(db)
+
+		const (
+			key   = "some-key"
+			value = "some-value"
+		)
+
+		err := store.Set(key, value)
+		require.NoError(t, err)
+
+		// Deleting valid key works.
+		err = store.Delete(key)
+		require.NoError(t, err)
+
+		// Value is no longer found.
+		_, err = store.Get(key)
+		require.ErrorIs(t, err, blockless.ErrNotFound)
+	})
 }

--- a/testing/mocks/peerstore.go
+++ b/testing/mocks/peerstore.go
@@ -10,9 +10,8 @@ import (
 )
 
 type PeerStore struct {
-	StoreFunc          func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
-	UpdatePeerListFunc func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
-	PeersFunc          func() ([]blockless.Peer, error)
+	StoreFunc func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
+	PeersFunc func() ([]blockless.Peer, error)
 }
 
 func BaselinePeerStore(t *testing.T) *PeerStore {
@@ -22,9 +21,7 @@ func BaselinePeerStore(t *testing.T) *PeerStore {
 		StoreFunc: func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error {
 			return nil
 		},
-		UpdatePeerListFunc: func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error {
-			return nil
-		},
+
 		PeersFunc: func() ([]blockless.Peer, error) {
 			return []blockless.Peer{}, nil
 		},
@@ -35,10 +32,6 @@ func BaselinePeerStore(t *testing.T) *PeerStore {
 
 func (p *PeerStore) Store(id peer.ID, addr multiaddr.Multiaddr, info peer.AddrInfo) error {
 	return p.StoreFunc(id, addr, info)
-}
-
-func (p *PeerStore) UpdatePeerList(id peer.ID, addr multiaddr.Multiaddr, info peer.AddrInfo) error {
-	return p.UpdatePeerListFunc(id, addr, info)
 }
 
 func (p *PeerStore) Peers() ([]blockless.Peer, error) {

--- a/testing/mocks/peerstore.go
+++ b/testing/mocks/peerstore.go
@@ -10,24 +10,35 @@ import (
 )
 
 type PeerStore struct {
-	StoreFunc func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
-	PeersFunc func() ([]blockless.Peer, error)
+	GetFunc    func(peer.ID) (blockless.Peer, error)
+	StoreFunc  func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error
+	PeersFunc  func() ([]blockless.Peer, error)
+	RemoveFunc func(peer.ID) error
 }
 
 func BaselinePeerStore(t *testing.T) *PeerStore {
 	t.Helper()
 
 	peerstore := PeerStore{
+		GetFunc: func(peer.ID) (blockless.Peer, error) {
+			return blockless.Peer{}, nil
+		},
 		StoreFunc: func(peer.ID, multiaddr.Multiaddr, peer.AddrInfo) error {
 			return nil
 		},
-
 		PeersFunc: func() ([]blockless.Peer, error) {
 			return []blockless.Peer{}, nil
+		},
+		RemoveFunc: func(peer.ID) error {
+			return GenericError
 		},
 	}
 
 	return &peerstore
+}
+
+func (p *PeerStore) Get(id peer.ID) (blockless.Peer, error) {
+	return p.GetFunc(id)
 }
 
 func (p *PeerStore) Store(id peer.ID, addr multiaddr.Multiaddr, info peer.AddrInfo) error {
@@ -36,4 +47,8 @@ func (p *PeerStore) Store(id peer.ID, addr multiaddr.Multiaddr, info peer.AddrIn
 
 func (p *PeerStore) Peers() ([]blockless.Peer, error) {
 	return p.PeersFunc()
+}
+
+func (p *PeerStore) Remove(id peer.ID) error {
+	return p.RemoveFunc(id)
 }

--- a/testing/mocks/store.go
+++ b/testing/mocks/store.go
@@ -9,6 +9,7 @@ type Store struct {
 	SetFunc       func(key string, value string) error
 	GetRecordFunc func(key string, value interface{}) error
 	SetRecordFunc func(key string, value interface{}) error
+	DeleteFunc    func(key string) error
 	KeysFunc      func() []string
 }
 
@@ -26,6 +27,9 @@ func BaselineStore(t *testing.T) *Store {
 			return nil
 		},
 		SetRecordFunc: func(string, interface{}) error {
+			return nil
+		},
+		DeleteFunc: func(string) error {
 			return nil
 		},
 		KeysFunc: func() []string {
@@ -50,6 +54,10 @@ func (s *Store) GetRecord(key string, value interface{}) error {
 
 func (s *Store) SetRecord(key string, value interface{}) error {
 	return s.SetRecordFunc(key, value)
+}
+
+func (s *Store) Delete(key string) error {
+	return s.DeleteFunc(key)
 }
 
 func (s *Store) Keys() []string {


### PR DESCRIPTION
Since we have split peers and functions to separate databases, we can simplify our peerstore implementation.

To list known peers - we can just iterate among the list of peers we have in the DB. I also extended the list of actions supported by the peerstore handler, even if we don't currently use all of them.

@dmikey
We currently store any connected host to the peerstore and try to dial back on restart. Do we want to remove hosts when they disconnect? I can see the reasons for both. For example a host can disconnect temporarily for whatever reason (e.g. reboot) and be back relatively soon. But also a peer could disappear for ages (or get a new identity). We can keep track of "last connect" timestamp and remove any that we haven't seen in a long time.