### PR TITLE
Introducing resource limits on Windows

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -134,9 +134,9 @@ func run() int {
 			}
 
 			defer func() {
-				err = limiter.RemoveAllLimits()
+				err = limiter.Shutdown()
 				if err != nil {
-					log.Error().Err(err).Msg("could not remove resource limtis")
+					log.Error().Err(err).Msg("could not shutdown resource limiter")
 				}
 			}()
 

--- a/executor/execute_ux.go
+++ b/executor/execute_ux.go
@@ -35,7 +35,7 @@ func (e *Executor) executeCommand(cmd *exec.Cmd) (execute.RuntimeOutput, execute
 	}
 	err = e.cfg.Limiter.LimitProcess(proc)
 	if err != nil {
-		return execute.RuntimeOutput{}, execute.Usage{}, fmt.Errorf("could not limit process: %w", err)
+		return execute.RuntimeOutput{}, execute.Usage{}, fmt.Errorf("could not set resource limits: %w", err)
 	}
 
 	// Return execution error with as much info below.

--- a/executor/execute_ux.go
+++ b/executor/execute_ux.go
@@ -30,7 +30,10 @@ func (e *Executor) executeCommand(cmd *exec.Cmd) (execute.RuntimeOutput, execute
 		return execute.RuntimeOutput{}, execute.Usage{}, fmt.Errorf("could not start process: %w", err)
 	}
 
-	err = e.cfg.Limiter.LimitProcess(cmd.Process.Pid)
+	proc := execute.ProcessID{
+		PID: cmd.Process.Pid,
+	}
+	err = e.cfg.Limiter.LimitProcess(proc)
 	if err != nil {
 		return execute.RuntimeOutput{}, execute.Usage{}, fmt.Errorf("could not limit process: %w", err)
 	}

--- a/executor/execute_windows.go
+++ b/executor/execute_windows.go
@@ -48,7 +48,14 @@ func (e *Executor) executeCommand(cmd *exec.Cmd) (execute.RuntimeOutput, execute
 	// Create a duplicate handle - only for me (current process), not inheritable.
 	var handle windows.Handle
 	me := windows.CurrentProcess()
-	err = windows.DuplicateHandle(me, childHandle, me, &handle, windows.PROCESS_QUERY_INFORMATION, false, 0)
+	err = windows.DuplicateHandle(
+		me,
+		childHandle,
+		me,
+		&handle,
+		windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_TERMINATE|windows.PROCESS_SET_QUOTA,
+		false,
+		0)
 	if err != nil {
 		return execute.RuntimeOutput{}, execute.Usage{}, fmt.Errorf("could not duplicate process handle: %w", err)
 	}

--- a/executor/execute_windows.go
+++ b/executor/execute_windows.go
@@ -66,6 +66,15 @@ func (e *Executor) executeCommand(cmd *exec.Cmd) (execute.RuntimeOutput, execute
 		}
 	}()
 
+	proc := execute.ProcessID{
+		PID:    cmd.Process.Pid,
+		Handle: uintptr(handle),
+	}
+	err = e.cfg.Limiter.LimitProcess(proc)
+	if err != nil {
+		return execute.RuntimeOutput{}, execute.Usage{}, fmt.Errorf("could not set resource limits: %w", err)
+	}
+
 	// Now we can safely wait for the child process to complete.
 	cmdErr := cmd.Wait()
 	end := time.Now()

--- a/executor/limiter.go
+++ b/executor/limiter.go
@@ -1,9 +1,13 @@
 package executor
 
+import (
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
 // noopLimiter is a dummy limiter used when processes run without any resource limitations.
 type noopLimiter struct{}
 
-func (n *noopLimiter) LimitProcess(pid int) error {
+func (n *noopLimiter) LimitProcess(proc execute.ProcessID) error {
 	return nil
 }
 

--- a/executor/limits.go
+++ b/executor/limits.go
@@ -1,6 +1,10 @@
 package executor
 
+import (
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
 type Limiter interface {
-	LimitProcess(pid int) error
+	LimitProcess(proc execute.ProcessID) error
 	ListProcesses() ([]int, error)
 }

--- a/executor/limits/config.go
+++ b/executor/limits/config.go
@@ -3,13 +3,16 @@ package limits
 // DefaultConfig describes the default process resource limits.
 var DefaultConfig = Config{
 	Cgroup:        DefaultCgroup,
+	JobName:       DefaultJobObjectName,
 	MemoryKB:      -1,
 	CPUPercentage: DefaultCPUPercentage,
 }
 
 // Config represents the resource limits to set.
 type Config struct {
-	Cgroup        string  // Cgroup to use for limits.
+	Cgroup  string // On Linux, Cgroup to use for limits.
+	JobName string // On Windows, job name to use for limits.
+
 	MemoryKB      int64   // Maximum amount of memory allowed in kilobytes.
 	CPUPercentage float64 // Percentage of the CPU time allowed.
 }
@@ -21,6 +24,13 @@ type Option func(*Config)
 func WithCgroup(path string) Option {
 	return func(cfg *Config) {
 		cfg.Cgroup = path
+	}
+}
+
+// WithJobObjectName sets the name for the job object to be used for the jobs.
+func WithJobObjectName(name string) Option {
+	return func(cfg *Config) {
+		cfg.JobName = name
 	}
 }
 

--- a/executor/limits/config.go
+++ b/executor/limits/config.go
@@ -11,7 +11,7 @@ var DefaultConfig = Config{
 // Config represents the resource limits to set.
 type Config struct {
 	Cgroup  string // On Linux, Cgroup to use for limits.
-	JobName string // On Windows, job name to use for limits.
+	JobName string // On Windows, job object name to use for limits.
 
 	MemoryKB      int64   // Maximum amount of memory allowed in kilobytes.
 	CPUPercentage float64 // Percentage of the CPU time allowed.

--- a/executor/limits/config_internal_test.go
+++ b/executor/limits/config_internal_test.go
@@ -41,3 +41,15 @@ func TestConfig_WithMemoryKB(t *testing.T) {
 	WithMemoryKB(limit)(&cfg)
 	require.Equal(t, limit, cfg.MemoryKB)
 }
+
+func TestConfig_JobName(t *testing.T) {
+
+	const jobName = "blockless-test"
+
+	cfg := Config{
+		JobName: DefaultJobObjectName,
+	}
+
+	WithJobObjectName(jobName)(&cfg)
+	require.Equal(t, jobName, cfg.JobName)
+}

--- a/executor/limits/job_windows.go
+++ b/executor/limits/job_windows.go
@@ -1,0 +1,91 @@
+//go:build windows
+// +build windows
+
+package limits
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	jobObjectBasicProcessIdListInformationClass = 3
+)
+
+const (
+	JOB_OBJECT_CPU_RATE_CONTROL_ENABLE = 0x1
+	// The job's CPU rate is a hard limit. After the job reaches its CPU cycle limit for the current scheduling interval,
+	// no threads associated with the job will run until the next interval.
+	// => See https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_cpu_rate_control_information
+	JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP = 0x4
+)
+
+type jobObjectCPURateControlInformation struct {
+	ControlFlags uint32
+	CPURate      uint32
+}
+
+func setCPULimit(h windows.Handle, cpuRate float64) error {
+
+	// Specifies the portion of processor cycles that the threads in a job object can use during each scheduling interval, as the number of cycles per 10,000 cycles.
+	// Set CpuRate to a percentage times 100. For example, to let the job use 20% of the CPU, set CpuRate to 20 times 100, or 2,000.
+	// => See https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_cpu_rate_control_information
+
+	info := &jobObjectCPURateControlInformation{
+		ControlFlags: JOB_OBJECT_CPU_RATE_CONTROL_ENABLE | JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP,
+
+		// Convert rate from e.g. 0.8 to 80(%) * 100.
+		CPURate: uint32((100 * cpuRate) * 100),
+	}
+
+	_, err := windows.SetInformationJobObject(
+		h,
+		windows.JobObjectCpuRateControlInformation,
+		uintptr(unsafe.Pointer(info)),
+		uint32(unsafe.Sizeof(*info)),
+	)
+	if err != nil {
+		return fmt.Errorf("could not set CPU limit for job: %w", err)
+	}
+
+	return nil
+}
+
+type jobObjectExtendedLimitInformation struct {
+	BasicLimitInformation windows.MemoryBasicInformation
+	IoInfo                ioCounters
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+type ioCounters struct {
+	ReadOperationCount  uint64
+	WriteOperationCount uint64
+	OtherOperationCount uint64
+	ReadTransferCount   uint64
+	WriteTransferCount  uint64
+	OtherTransferCount  uint64
+}
+
+func setMemLimit(h windows.Handle, memoryKB int64) error {
+
+	info := &jobObjectExtendedLimitInformation{
+		JobMemoryLimit: uintptr(memoryKB * 1000),
+	}
+
+	_, err := windows.SetInformationJobObject(
+		h,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(info)),
+		uint32(unsafe.Sizeof(*info)),
+	)
+	if err != nil {
+		return fmt.Errorf("could not set memory limit for job: %w", err)
+	}
+
+	return nil
+}

--- a/executor/limits/limits_gen.go
+++ b/executor/limits/limits_gen.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux && !windows
+// +build !linux,!windows
 
 package limits
 
@@ -30,5 +30,10 @@ func (l *Limits) ListProcesses() ([]int, error) {
 
 // RemoveAllLimits will remove any set resource limits.
 func (l *Limits) RemoveAllLimits() error {
+	return errors.New("TBD: not implemented")
+}
+
+// Close will close the limiter.
+func (l *Limits) Close() error {
 	return errors.New("TBD: not implemented")
 }

--- a/executor/limits/limits_integration_test.go
+++ b/executor/limits/limits_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blocklessnetworking/b7s/executor/limits"
+	"github.com/blocklessnetworking/b7s/models/execute"
 )
 
 const (
@@ -53,18 +54,20 @@ func TestLimits(t *testing.T) {
 
 	// Put resource limit on self.
 	// This is effectively a limit on go test so we're conservative with limits.
-	pid := os.Getpid()
-	err = limiter.LimitProcess(pid)
+	proc := execute.ProcessID{
+		PID: os.Getpid(),
+	}
+	err = limiter.LimitProcess(proc)
 	require.NoError(t, err)
 
 	// Verify list of limited processes now has a single process.
 	pids, err = limiter.ListProcesses()
 	require.NoError(t, err)
 	require.Len(t, pids, 1)
-	require.Equal(t, pids[0], pid)
+	require.Equal(t, pids[0], proc.PID)
 
 	// Manually verify the PID limit.
-	verifyPids(t, cgroup, []int{pid})
+	verifyPids(t, cgroup, []int{proc.PID})
 }
 
 func verifyCPULImit(t *testing.T, cgroup string, limit float64) {

--- a/executor/limits/limits_linux.go
+++ b/executor/limits/limits_linux.go
@@ -85,8 +85,8 @@ func (l *Limits) ListProcesses() ([]int, error) {
 	return list, nil
 }
 
-// RemoveAllLimits will remove any set resource limits.
-func (l *Limits) RemoveAllLimits() error {
+// Shutdown will remove any set resource limits.
+func (l *Limits) Shutdown() error {
 
 	// Remove all limits effectively sets them to very large values, which is different from "removing" them.
 	period := uint64(time.Second.Microseconds())
@@ -106,10 +106,5 @@ func (l *Limits) RemoveAllLimits() error {
 		return fmt.Errorf("could not update resource limits: %v", err)
 	}
 
-	return nil
-}
-
-// Close will close the limiter.
-func (l *Limits) Close() error {
 	return nil
 }

--- a/executor/limits/limits_linux.go
+++ b/executor/limits/limits_linux.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup2"
+
+	"github.com/blocklessnetworking/b7s/models/execute"
 )
 
 // TODO: Add support for cgroups v1 - determine on the fly which version to use

--- a/executor/limits/limits_linux.go
+++ b/executor/limits/limits_linux.go
@@ -56,8 +56,9 @@ func New(opts ...Option) (*Limits, error) {
 }
 
 // LimitProcess will set the resource limits for the process with the given PID.
-func (l *Limits) LimitProcess(pid int) error {
+func (l *Limits) LimitProcess(proc execute.ProcessID) error {
 
+	pid := proc.PID
 	err := l.cgroup.AddProc(uint64(pid))
 	if err != nil {
 		return fmt.Errorf("could not set resouce limit for process (pid: %v): %w", pid, err)

--- a/executor/limits/limits_linux.go
+++ b/executor/limits/limits_linux.go
@@ -105,3 +105,8 @@ func (l *Limits) RemoveAllLimits() error {
 
 	return nil
 }
+
+// Close will close the limiter.
+func (l *Limits) Close() error {
+	return nil
+}

--- a/executor/limits/limits_linux_integration_test.go
+++ b/executor/limits/limits_linux_integration_test.go
@@ -1,5 +1,5 @@
-//go:build limits
-// +build limits
+//go:build limits && linux
+// +build limits,linux
 
 package limits_test
 
@@ -38,9 +38,9 @@ func TestLimits(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Always remove all resource limits.
+	// Always remove all resource limits on end of test.
 	defer func() {
-		err = limiter.RemoveAllLimits()
+		err = limiter.Shutdown()
 		require.NoError(t, err)
 	}()
 

--- a/executor/limits/limits_windows.go
+++ b/executor/limits/limits_windows.go
@@ -85,7 +85,7 @@ func (l *Limits) ListProcesses() ([]int, error) {
 // Shutdown will shutdown the limiter. All processes currently associated with the limiter will complete
 // their execution as-is, meaning that the limitations will not be removed.
 // "After a process is associated with a job, the association cannot be broken"
-// See => https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects#creating-jobs.
+// => See https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects#creating-jobs.
 func (l *Limits) Shutdown() error {
 
 	err := windows.CloseHandle(l.jh)

--- a/executor/limits/limits_windows.go
+++ b/executor/limits/limits_windows.go
@@ -82,15 +82,16 @@ func (l *Limits) ListProcesses() ([]int, error) {
 	return pids, nil
 }
 
-// Close will close the limiter.
-func (l *Limits) Close() error {
-	return windows.CloseHandle(l.jh)
-}
-
-// RemoveAllLimits exists to maintain the same interface as the linux version.
-// However, the Windows limiter does not support removing limits from a job after it has been set:
+// Shutdown will shutdown the limiter. All processes currently associated with the limiter will complete
+// their execution as-is, meaning that the limitations will not be removed.
 // "After a process is associated with a job, the association cannot be broken"
 // See => https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects#creating-jobs.
-func (l *Limits) RemoveAllLimits() error {
+func (l *Limits) Shutdown() error {
+
+	err := windows.CloseHandle(l.jh)
+	if err != nil {
+		return fmt.Errorf("could not close job object: %w", err)
+	}
+
 	return nil
 }

--- a/executor/limits/limits_windows.go
+++ b/executor/limits/limits_windows.go
@@ -63,7 +63,8 @@ func New(opts ...Option) (*Limits, error) {
 // LimitProcess will set the resource limits for the process identified by the handle.
 func (l *Limits) LimitProcess(proc execute.ProcessID) error {
 
-	err := windows.AssignProcessToJobObject(l.jh, proc.Handle)
+	handle := windows.Handle(proc.Handle)
+	err := windows.AssignProcessToJobObject(l.jh, handle)
 	if err != nil {
 		return fmt.Errorf("could not assign job to job object: %w", err)
 	}
@@ -84,4 +85,12 @@ func (l *Limits) ListProcesses() ([]int, error) {
 // Close will close the limiter.
 func (l *Limits) Close() error {
 	return windows.CloseHandle(l.jh)
+}
+
+// RemoveAllLimits exists to maintain the same interface as the linux version.
+// However, the Windows limiter does not support removing limits from a job after it has been set:
+// "After a process is associated with a job, the association cannot be broken"
+// See => https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects#creating-jobs.
+func (l *Limits) RemoveAllLimits() error {
+	return nil
 }

--- a/executor/limits/limits_windows.go
+++ b/executor/limits/limits_windows.go
@@ -1,0 +1,129 @@
+//go:build windows
+// +build windows
+
+package limits
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type Limits struct {
+	cfg Config
+
+	jh windows.Handle
+}
+
+// New creates a new process resource limit with the given configuration.
+func New(opts ...Option) (*Limits, error) {
+
+	// Create job object to which executions will be assigned to.
+	name, err := windows.UTF16PtrFromString(DefaultJobObjectName)
+	if err != nil {
+		return nil, fmt.Errorf("could not prepare job object name: %w", err)
+	}
+
+	h, err := windows.CreateJobObject(nil, name)
+	if err != nil {
+		return nil, fmt.Errorf("could not create job object: %w", err)
+	}
+
+	cfg := DefaultConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.CPUPercentage < 1.0 {
+		err := setCPULimit(h, cfg.CPUPercentage)
+		if err != nil {
+			windows.CloseHandle(h)
+			return nil, fmt.Errorf("could not set CPU limit: %w", err)
+		}
+	}
+
+	if cfg.MemoryKB > 0 {
+		err := setMemLimit(h, cfg.MemoryKB)
+		if err != nil {
+			windows.CloseHandle(h)
+			return nil, fmt.Errorf("could not set memory limit: %w", err)
+		}
+	}
+
+	l := Limits{
+		cfg: cfg,
+		jh:  h,
+	}
+
+	return &l, nil
+}
+
+// LimitProcess will set the resource limits for the process identified by the handle.
+func (l *Limits) LimitProcess(proc windows.Handle) error {
+
+	err := windows.AssignProcessToJobObject(l.jh, proc)
+	if err != nil {
+		return fmt.Errorf("could not assign job to job object: %w", err)
+	}
+
+	return nil
+}
+
+type jobObjectBasicProcessIdList struct {
+	NumberOfAssignedProcesses uint32
+	NumberOfProcessIDsInList  uint32
+	ProcessIDList             [1]uintptr
+}
+
+func (l *Limits) ListProcesses() ([]int, error) {
+
+	info := &jobObjectBasicProcessIdList{}
+
+	err := windows.QueryInformationJobObject(
+		l.jh,
+		jobObjectBasicProcessIdListInformationClass,
+		uintptr(unsafe.Pointer(info)),
+		uint32(unsafe.Sizeof(*info)),
+		nil,
+	)
+	if err == nil {
+		if info.NumberOfProcessIDsInList == 1 {
+			return []int{
+				int(info.ProcessIDList[0]),
+			}, nil
+		}
+
+		return []int{}, nil
+	}
+
+	// TODO: Check if the error here is `ERROR_MORE_DATA`.
+	if err != nil {
+		return nil, fmt.Errorf("could not list job object processes: %w", err)
+	}
+
+	bufSize := unsafe.Sizeof(info) + (unsafe.Sizeof(info.ProcessIDList[0]) * uintptr(info.NumberOfAssignedProcesses-1))
+	buf := make([]byte, bufSize)
+
+	err = windows.QueryInformationJobObject(
+		l.jh,
+		jobObjectBasicProcessIdListInformationClass,
+		uintptr(unsafe.Pointer(&buf[0])),
+		uint32(unsafe.Sizeof(len(buf))),
+		nil,
+	)
+
+	bufInfo := (*jobObjectBasicProcessIdList)(unsafe.Pointer(&buf[0]))
+	pids := make([]int, 0, bufInfo.NumberOfProcessIDsInList)
+	for _, pid := range bufInfo.ProcessIDList {
+		p := int(pid)
+		pids = append(pids, p)
+	}
+
+	return pids, nil
+}
+
+// Close will close the limiter.
+func (l *Limits) Close() error {
+	return windows.CloseHandle(l.jh)
+}

--- a/executor/limits/limits_windows_test.go
+++ b/executor/limits/limits_windows_test.go
@@ -1,0 +1,82 @@
+//go:build windows
+// +build windows
+
+package limits_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+
+	"github.com/blocklessnetworking/b7s/executor/limits"
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+func TestLimits(t *testing.T) {
+
+	// NOTE: We currently don't have an implementation to query set resource limits.
+	// What we can do is spin up another process and limit it by assigning it to the job object.
+	// We can then query if the process PID is indeed assigned - verifying that the job object
+	// exists and the process has been assigned to it, providing *some* assurance.
+
+	const (
+		cpuLimit = 0.95
+		memLimit = 256_000
+
+		// We use ping to simulate "sleep", more info below.
+		pingPath = `C:\Windows\System32\ping.exe`
+	)
+
+	limiter, err := limits.New(
+		limits.WithCPUPercentage(cpuLimit),
+		limits.WithMemoryKB(memLimit),
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		err = limiter.Shutdown()
+		require.NoError(t, err)
+	}()
+
+	// Verify list of limited processes is empty.
+	pids, err := limiter.ListProcesses()
+	require.NoError(t, err)
+	require.Empty(t, pids)
+
+	// Ideally we want to run something like "sleep" for a few seconds.
+	// However, "sleep" is not present by default on Windows. There is a "timeout" alternative,
+	// but it does not support running programmatically because of input redirection - it expects
+	// user input to stop waiting. Instead we'll just use a "ping" on the loopback address.
+	// => See https://www.ibm.com/support/pages/timeout-command-run-batch-job-exits-immediately-and-returns-error-input-redirection-not-supported-exiting-process-immediately
+	cmd := exec.Command(pingPath, "-n", "1", "127.0.0.1")
+
+	err = cmd.Start()
+	require.NoError(t, err)
+
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_TERMINATE|windows.PROCESS_SET_QUOTA,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	require.NoError(t, err)
+
+	defer windows.CloseHandle(handle)
+
+	proc := execute.ProcessID{
+		PID:    cmd.Process.Pid,
+		Handle: uintptr(handle),
+	}
+	err = limiter.LimitProcess(proc)
+	require.NoError(t, err)
+
+	pids, err = limiter.ListProcesses()
+	require.NoError(t, err)
+
+	require.Len(t, pids, 1)
+	require.Equal(t, cmd.Process.Pid, pids[0])
+
+	err = cmd.Wait()
+	require.NoError(t, err)
+}

--- a/executor/limits/params.go
+++ b/executor/limits/params.go
@@ -1,8 +1,9 @@
 package limits
 
 const (
-	DefaultCgroup     = "/blockless"
-	DefaultMountpoint = "/sys/fs/cgroup"
+	DefaultCgroup        = "/blockless"
+	DefaultMountpoint    = "/sys/fs/cgroup"
+	DefaultJobObjectName = "blockless"
 
 	// Default percentage of the CPU allowed. By default we run unlimited.
 	DefaultCPUPercentage = 1.0

--- a/models/execute/process.go
+++ b/models/execute/process.go
@@ -1,0 +1,11 @@
+package execute
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// ProcessID is used to identify an OS process.
+type ProcessID struct {
+	PID    int            // PID can used to identify a process on all platforms.
+	Handle windows.Handle // Handle can be used for Windows-specific operations.
+}

--- a/models/execute/process.go
+++ b/models/execute/process.go
@@ -1,11 +1,7 @@
 package execute
 
-import (
-	"golang.org/x/sys/windows"
-)
-
 // ProcessID is used to identify an OS process.
 type ProcessID struct {
-	PID    int            // PID can used to identify a process on all platforms.
-	Handle windows.Handle // Handle can be used for Windows-specific operations.
+	PID    int     // PID can used to identify a process on all platforms.
+	Handle uintptr // windows.Handle value that can be used for Windows-specific operations.
 }


### PR DESCRIPTION
This PR introduces resource limits on Windows. These are not request-specific limits, but cumulative limits for all Blockless Runtime executions.

## Implementation

Resource limits are set using [Job Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects).

Since Go syscall documentation is scarce, here is MSDN documentation for relevant syscalls:
- [CreateJobObject](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createjobobjecta)
- [AssignProcessToJobObject](https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject)
- [QueryInformationJobObject](https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-queryinformationjobobject)

## Testing

To test this manually, I used [this code](https://github.com/Maelkum/b7s-toolbox/blob/master/cmd/limits/main.go) to spin up a number of processes, and the [hcsshim jobobject-util](https://github.com/microsoft/hcsshim/blob/main/cmd/jobobject-util/main.go) tool to query resource limits for the job object; also tweaked it locally to print out pids of the assigned processes.

Also tested with a full-fledged `executor`.

For Go test code, I spun up another process doing a sleep* and created resource limits for it.

\* - because Windows doesn't have `sleep` by default and `timeout.exe` cannot be used in scripts, I used a variant with a ping to localhost to simulate sleep
