### PR TITLE
Updating tests for fstore

### DIFF
--- a/fstore/sync_internal_test.go
+++ b/fstore/sync_internal_test.go
@@ -1,0 +1,82 @@
+package fstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestFstore_CheckFunctionFiles(t *testing.T) {
+
+	workdir, err := os.MkdirTemp("", "b7s-function-get-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(workdir)
+
+	store := mocks.BaselineStore(t)
+	fh := New(mocks.NoopLogger, store, workdir)
+
+	var (
+		archiveName      = "archive.tar.gz"
+		functionFileName = "function-file"
+	)
+
+	rec := functionRecord{
+		Archive: archiveName,
+		Files:   functionFileName,
+	}
+
+	t.Run("archive and function not found", func(t *testing.T) {
+
+		haveArchive, haveFiles, err := fh.checkFunctionFiles(rec)
+		require.NoError(t, err)
+
+		require.False(t, haveArchive)
+		require.False(t, haveFiles)
+	})
+	t.Run("archive and function found", func(t *testing.T) {
+
+		archivePath := filepath.Join(workdir, archiveName)
+		_, err := os.Create(archivePath)
+		require.NoError(t, err)
+		defer os.Remove(archivePath)
+
+		functionPath := filepath.Join(workdir, functionFileName)
+		_, err = os.Create(functionPath)
+		require.NoError(t, err)
+		defer os.Remove(functionPath)
+
+		haveArchive, haveFiles, err := fh.checkFunctionFiles(rec)
+		require.NoError(t, err)
+		require.True(t, haveArchive)
+		require.True(t, haveFiles)
+	})
+	t.Run("archive found, function files missing", func(t *testing.T) {
+
+		archivePath := filepath.Join(workdir, archiveName)
+		_, err := os.Create(archivePath)
+		require.NoError(t, err)
+		defer os.Remove(archivePath)
+
+		haveArchive, haveFiles, err := fh.checkFunctionFiles(rec)
+		require.NoError(t, err)
+		require.True(t, haveArchive)
+		require.False(t, haveFiles)
+	})
+	t.Run("archive missing, function files found", func(t *testing.T) {
+
+		functionPath := filepath.Join(workdir, functionFileName)
+		_, err = os.Create(functionPath)
+		require.NoError(t, err)
+		defer os.Remove(functionPath)
+
+		haveArchive, haveFiles, err := fh.checkFunctionFiles(rec)
+		require.NoError(t, err)
+		require.False(t, haveArchive)
+		require.True(t, haveFiles)
+	})
+}

--- a/node/execute_internal_test.go
+++ b/node/execute_internal_test.go
@@ -162,7 +162,7 @@ func TestNode_WorkerExecute(t *testing.T) {
 		node := createNode(t, blockless.WorkerNode)
 
 		// Error retrieving function manifest.
-		fstore := mocks.BaselineFunctionHandler(t)
+		fstore := mocks.BaselineFStore(t)
 		fstore.InstalledFunc = func(string) (bool, error) {
 			return false, mocks.GenericError
 		}

--- a/node/health_internal_test.go
+++ b/node/health_internal_test.go
@@ -28,7 +28,7 @@ func TestNode_Health(t *testing.T) {
 	var (
 		logger          = mocks.NoopLogger
 		peerstore       = mocks.BaselinePeerStore(t)
-		functionHandler = mocks.BaselineFunctionHandler(t)
+		functionHandler = mocks.BaselineFStore(t)
 	)
 
 	// Create a node with a short health interval that will issue quick pings.

--- a/node/node_internal_test.go
+++ b/node/node_internal_test.go
@@ -39,7 +39,7 @@ func TestNode_New(t *testing.T) {
 	var (
 		logger          = mocks.NoopLogger
 		peerstore       = mocks.BaselinePeerStore(t)
-		functionHandler = mocks.BaselineFunctionHandler(t)
+		functionHandler = mocks.BaselineFStore(t)
 		executor        = mocks.BaselineExecutor(t)
 	)
 
@@ -95,7 +95,7 @@ func createNode(t *testing.T, role blockless.NodeRole) *Node {
 	var (
 		logger          = mocks.NoopLogger
 		peerstore       = mocks.BaselinePeerStore(t)
-		functionHandler = mocks.BaselineFunctionHandler(t)
+		functionHandler = mocks.BaselineFStore(t)
 	)
 
 	host, err := host.New(logger, loopback, 0)

--- a/node/notifiee_internal_test.go
+++ b/node/notifiee_internal_test.go
@@ -17,7 +17,7 @@ func TestNode_Notifiee(t *testing.T) {
 
 	var (
 		logger          = mocks.NoopLogger
-		functionHandler = mocks.BaselineFunctionHandler(t)
+		functionHandler = mocks.BaselineFStore(t)
 	)
 
 	server, err := host.New(mocks.NoopLogger, loopback, 0)

--- a/node/rest_internal_test.go
+++ b/node/rest_internal_test.go
@@ -1,0 +1,63 @@
+package node
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/codes"
+	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestNode_RestExecute(t *testing.T) {
+
+	var (
+		request = mocks.GenericExecutionRequest
+
+		result = execute.Result{
+			Code: codes.OK,
+			Result: execute.RuntimeOutput{
+				Stdout:   "executor-output",
+				Stderr:   "executor stderr log",
+				ExitCode: 101,
+			},
+		}
+	)
+
+	node := createNode(t, blockless.WorkerNode)
+
+	executor := mocks.BaselineExecutor(t)
+	executor.ExecFunctionFunc = func(requestID string, req execute.Request) (execute.Result, error) {
+		return result, nil
+	}
+	node.executor = executor
+
+	code, results, err := node.ExecuteFunction(context.Background(), request)
+	require.NoError(t, err)
+
+	require.Equal(t, result.Code, code)
+	require.Len(t, results, 1)
+
+	// Worker node should provide only its own result.
+	nodeID := node.host.ID().String()
+	res, ok := results[nodeID]
+	require.True(t, ok)
+	require.Equal(t, result, res)
+}
+
+func TestNode_InstallMessageFromCID(t *testing.T) {
+
+	const (
+		cid                 = "dummy-cid"
+		expectedManifestURL = "https://dummy-cid.ipfs.w3s.link/manifest.json"
+	)
+
+	req := createInstallMessageFromCID(cid)
+
+	require.Equal(t, blockless.MessageInstallFunction, req.Type)
+	require.Equal(t, cid, req.CID)
+	require.Equal(t, expectedManifestURL, req.ManifestURL)
+}

--- a/node/roll_call_internal_test.go
+++ b/node/roll_call_internal_test.go
@@ -84,7 +84,7 @@ func TestNode_RollCall(t *testing.T) {
 		hostAddNewPeer(t, node.host, receiver)
 
 		// Function store fails to check function presence.
-		fstore := mocks.BaselineFunctionHandler(t)
+		fstore := mocks.BaselineFStore(t)
 		fstore.InstalledFunc = func(string) (bool, error) {
 			return false, mocks.GenericError
 		}
@@ -126,7 +126,7 @@ func TestNode_RollCall(t *testing.T) {
 		hostAddNewPeer(t, node.host, receiver)
 
 		// Function store has no function but is able to install it.
-		fstore := mocks.BaselineFunctionHandler(t)
+		fstore := mocks.BaselineFStore(t)
 		fstore.InstalledFunc = func(string) (bool, error) {
 			return false, nil
 		}
@@ -171,7 +171,7 @@ func TestNode_RollCall(t *testing.T) {
 		hostAddNewPeer(t, node.host, receiver)
 
 		// Function store has no function but is not able to install it.
-		fstore := mocks.BaselineFunctionHandler(t)
+		fstore := mocks.BaselineFStore(t)
 		fstore.InstalledFunc = func(string) (bool, error) {
 			return false, nil
 		}

--- a/node/sync_internal_test.go
+++ b/node/sync_internal_test.go
@@ -1,0 +1,39 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNode_Sync(t *testing.T) {
+
+	var (
+		installed = []string{
+			"func1",
+			"func2",
+			"func3",
+		}
+
+		synced []string
+	)
+
+	fstore := mocks.BaselineFStore(t)
+	fstore.InstalledFunctionsFunc = func() []string {
+		return installed
+	}
+	fstore.SyncFunc = func(cid string) error {
+		synced = append(synced, cid)
+		return nil
+	}
+
+	node := createNode(t, blockless.WorkerNode)
+	node.fstore = fstore
+
+	node.syncFunctions()
+
+	// Verify all functions were synced.
+	require.Equal(t, installed, synced)
+}

--- a/testing/mocks/fstore.go
+++ b/testing/mocks/fstore.go
@@ -14,7 +14,7 @@ type FStore struct {
 	SyncFunc               func(string) error
 }
 
-func BaselineFunctionHandler(t *testing.T) *FStore {
+func BaselineFStore(t *testing.T) *FStore {
 	t.Helper()
 
 	fh := FStore{


### PR DESCRIPTION
This PR adds tests for some of the recent functionality:

- function sync (and checking if function is present on local storage)
- skipping inadequare roll call responses
- some REST endpoints

Working on adding tests for the `host` package too but will open it in a separate PR when done.