### PR TITLE
Add option websocket endpoint for node

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,26 @@ You can also use Docker to install b7s. See the [Docker documentation](/docker/R
 
 ## Usage
 
-| Flag             | Short Form | Default Value           | Description                                                                                   |
-| ---------------- | ---------- | ----------------------- | --------------------------------------------------------------------------------------------- |
-| log-level        | -l         | "info"                  | Specifies the level of logging to use.                                                        |
-| peer-db          | N/A        | "peer-db"               | Specifies the path to database used for persisting peer data.                                 |
-| function-db      | N/A        | "function-db"           | Specifies the path to database used for persisting function data.                             |
-| role             | -r         | "worker"                | Specifies the role this node will have in the Blockless protocol (head or worker).            |
-| address          | -a         | "0.0.0.0"               | Specifies the address that the libp2p host will use.                                          |
-| port             | -p         | 0                       | Specifies the port that the libp2p host will use.                                             |
-| private-key      | N/A        | N/A                     | Specifies the private key that the libp2p host will use.                                      |
-| concurrency      | -c         | node.DefaultConcurrency | Specifies the maximum number of requests the node will process in parallel.                   |
-| rest-api         | N/A        | N/A                     | Specifies the address where the head node REST API will listen on.                            |
-| boot-nodes       | N/A        | N/A                     | Specifies a list of addresses that this node will connect to on startup, in multiaddr format. |
-| workspace        | N/A        | "./workspace"           | Specifies the directory that the node can use for file storage.                               |
-| runtime          | N/A        | N/A                     | Specifies the runtime address used by the worker node.                                        |
-| dialback-address | N/A        | N/A                     | Specifies the advertised dialback address of the Node.                                        |
-| dialback-port    | N/A        | N/A                     | Specifies the advertised dialback port of the Node.                                           |
-| cpu-percentage-limit | N/A | 1.0 | Specifies the amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited. |
-| memory-limit | N/A | N/A | Specifies the memory limit for Blockless Functions, in kB. |
+| Flag                      | Short Form | Default Value           | Description                                                                                   |
+| ------------------------- | ---------- | ----------------------- | --------------------------------------------------------------------------------------------- |
+| log-level                 | -l         | "info"                  | Specifies the level of logging to use.                                                        |
+| peer-db                   | N/A        | "peer-db"               | Specifies the path to database used for persisting peer data.                                 |
+| function-db               | N/A        | "function-db"           | Specifies the path to database used for persisting function data.                             |
+| role                      | -r         | "worker"                | Specifies the role this node will have in the Blockless protocol (head or worker).            |
+| address                   | -a         | "0.0.0.0"               | Specifies the address that the libp2p host will use.                                          |
+| port                      | -p         | 0                       | Specifies the port that the libp2p host will use.                                             |
+| websocket-port            | N/A        | 0                       | Specifies the port that the libp2p host will use for websocket connections.                   |
+| private-key               | N/A        | N/A                     | Specifies the private key that the libp2p host will use.                                      |
+| concurrency               | -c         | node.DefaultConcurrency | Specifies the maximum number of requests the node will process in parallel.                   |
+| rest-api                  | N/A        | N/A                     | Specifies the address where the head node REST API will listen on.                            |
+| boot-nodes                | N/A        | N/A                     | Specifies a list of addresses that this node will connect to on startup, in multiaddr format. |
+| workspace                 | N/A        | "./workspace"           | Specifies the directory that the node can use for file storage.                               |
+| runtime                   | N/A        | N/A                     | Specifies the runtime address used by the worker node.                                        |
+| dialback-address          | N/A        | N/A                     | Specifies the advertised dialback address of the Node.                                        |
+| dialback-port             | N/A        | N/A                     | Specifies the advertised dialback port of the Node.                                           |
+| websocket-dialback-port   | N/A        | 0                       | Specifies the advertised dialback port for Websocket connections.
+| cpu-percentage-limit      | N/A        | 1.0                     | Specifies the amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited. |
+| memory-limit              | N/A        | N/A                     | Specifies the memory limit for Blockless Functions, in kB. |
 
 ## Dependencies
 

--- a/cmd/node/README.md
+++ b/cmd/node/README.md
@@ -21,23 +21,25 @@ Head Nodes also serve a REST API that can be used to query or trigger certain ac
 
 ```console
 Usage of node:
-  -l, --log-level string             log level to use (default "info")
-      --peer-db string               path to the database used for persisting peer data (default "peer-db")
-      --function-db string           path to the database used for persisting function data (default "function-db")
-  -c, --concurrency uint             maximum number of requests node will process in parallel (default 10)
-      --rest-api string              address where the head node REST API will listen on
-      --workspace string             directory that the node can use for file storage (default "./workspace")
-      --runtime string               runtime address (used by the worker node)
-  -r, --role string                  role this note will have in the Blockless protocol (head or worker) (default "worker")
-      --private-key string           private key that the b7s host will use
-  -a, --address string               address that the b7s host will use (default "0.0.0.0")
-  -p, --port uint                    port that the b7s host will use
-      --dialback-address string      external address that the b7s host will advertise (default "0.0.0.0")
-      --dialback-port uint           external port that the b7s host will advertise
-  -w, --websocket                    should the node use websocket protocol for communication
-      --boot-nodes strings           list of addresses that this node will connect to on startup, in multiaddr format
-      --cpu-percentage-limit float   amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited (default 1)
-      --memory-limit int             memory limit (kB) for Blockless Functions
+  -l, --log-level string               log level to use (default "info")
+  -r, --role string                    role this note will have in the Blockless protocol (head or worker) (default "worker")
+      --peer-db string                 path to the database used for persisting peer data (default "peer-db")
+      --function-db string             path to the database used for persisting function data (default "function-db")
+  -c, --concurrency uint               maximum number of requests node will process in parallel (default 10)
+      --rest-api string                address where the head node REST API will listen on
+      --workspace string               directory that the node can use for file storage (default "./workspace")
+      --runtime string                 runtime address (used by the worker node)
+      --private-key string             private key that the b7s host will use
+  -a, --address string                 address that the b7s host will use (default "0.0.0.0")
+  -p, --port uint                      port that the b7s host will use
+      --boot-nodes strings             list of addresses that this node will connect to on startup, in multiaddr format
+      --dialback-address string        external address that the b7s host will advertise (default "0.0.0.0")
+      --dialback-port uint             external port that the b7s host will advertise
+      --websocket-dialback-port uint   external port that the b7s host will advertise for websocket connections
+  -w, --websocket                      should the node use websocket protocol for communication
+      --websocket-port uint            port to use for websocket connections
+      --cpu-percentage-limit float     amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited (default 1)
+      --memory-limit int               memory limit (kB) for Blockless Functions
 ```
 
 You can find more information about `multiaddr` format for network addresses [here](https://github.com/multiformats/multiaddr) and [here](https://multiformats.io/multiaddr/).

--- a/cmd/node/README.md
+++ b/cmd/node/README.md
@@ -24,17 +24,18 @@ Usage of node:
   -l, --log-level string             log level to use (default "info")
       --peer-db string               path to the database used for persisting peer data (default "peer-db")
       --function-db string           path to the database used for persisting function data (default "function-db")
+  -c, --concurrency uint             maximum number of requests node will process in parallel (default 10)
+      --rest-api string              address where the head node REST API will listen on
+      --workspace string             directory that the node can use for file storage (default "./workspace")
+      --runtime string               runtime address (used by the worker node)
   -r, --role string                  role this note will have in the Blockless protocol (head or worker) (default "worker")
+      --private-key string           private key that the b7s host will use
   -a, --address string               address that the b7s host will use (default "0.0.0.0")
   -p, --port uint                    port that the b7s host will use
       --dialback-address string      external address that the b7s host will advertise (default "0.0.0.0")
       --dialback-port uint           external port that the b7s host will advertise
-      --private-key string           private key that the b7s host will use
-  -c, --concurrency uint             maximum number of requests node will process in parallel (default 10)
-      --rest-api string              address where the head node REST API will listen on
+  -w, --websocket                    should the node use websocket protocol for communication
       --boot-nodes strings           list of addresses that this node will connect to on startup, in multiaddr format
-      --workspace string             directory that the node can use for file storage (default "./workspace")
-      --runtime string               runtime address (used by the worker node)
       --cpu-percentage-limit float   amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited (default 1)
       --memory-limit int             memory limit (kB) for Blockless Functions
 ```

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -26,6 +26,7 @@ func parseFlags() *config.Config {
 	pflag.StringVarP(&cfg.Log.Level, "log-level", "l", "info", "log level to use")
 
 	// Node configuration.
+	pflag.StringVarP(&cfg.Role, "role", "r", defaultRole, "role this note will have in the Blockless protocol (head or worker)")
 	pflag.StringVar(&cfg.PeerDatabasePath, "peer-db", defaultPeerDB, "path to the database used for persisting peer data")
 	pflag.StringVar(&cfg.FunctionDatabasePath, "function-db", defaultFunctionDB, "path to the database used for persisting function data")
 	pflag.UintVarP(&cfg.Concurrency, "concurrency", "c", defaultConcurrency, "maximum number of requests node will process in parallel")
@@ -34,14 +35,19 @@ func parseFlags() *config.Config {
 	pflag.StringVar(&cfg.Runtime, "runtime", "", "runtime address (used by the worker node)")
 
 	// Host configuration.
-	pflag.StringVarP(&cfg.Role, "role", "r", defaultRole, "role this note will have in the Blockless protocol (head or worker)")
 	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the b7s host will use")
 	pflag.StringVarP(&cfg.Host.Address, "address", "a", defaultAddress, "address that the b7s host will use")
 	pflag.UintVarP(&cfg.Host.Port, "port", "p", defaultPort, "port that the b7s host will use")
+	pflag.StringSliceVar(&cfg.BootNodes, "boot-nodes", nil, "list of addresses that this node will connect to on startup, in multiaddr format")
+
+	// For external IPs.
 	pflag.StringVarP(&cfg.Host.DialBackAddress, "dialback-address", "", defaultAddress, "external address that the b7s host will advertise")
 	pflag.UintVarP(&cfg.Host.DialBackPort, "dialback-port", "", defaultPort, "external port that the b7s host will advertise")
+	pflag.UintVarP(&cfg.Host.DialBackWebsocketPort, "websocket-dialback-port", "", defaultPort, "external port that the b7s host will advertise for websocket connections")
+
+	// Websocket connection.
 	pflag.BoolVarP(&cfg.Host.Websocket, "websocket", "w", defaultUseWebsocket, "should the node use websocket protocol for communication")
-	pflag.StringSliceVar(&cfg.BootNodes, "boot-nodes", nil, "list of addresses that this node will connect to on startup, in multiaddr format")
+	pflag.UintVar(&cfg.Host.WebsocketPort, "websocket-port", defaultPort, "port to use for websocket connections")
 
 	// Limit configuration.
 	pflag.Float64Var(&cfg.CPUPercentage, "cpu-percentage-limit", 1.0, "amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited")

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -9,11 +9,12 @@ import (
 
 // Default values.
 const (
-	defaultPort        = 0
-	defaultAddress     = "0.0.0.0"
-	defaultPeerDB      = "peer-db"
-	defaultFunctionDB  = "function-db"
-	defaultConcurrency = uint(node.DefaultConcurrency)
+	defaultPort         = 0
+	defaultAddress      = "0.0.0.0"
+	defaultPeerDB       = "peer-db"
+	defaultFunctionDB   = "function-db"
+	defaultConcurrency  = uint(node.DefaultConcurrency)
+	defaultUseWebsocket = false
 
 	defaultRole = "worker"
 )
@@ -23,25 +24,26 @@ func parseFlags() *config.Config {
 	var cfg config.Config
 
 	pflag.StringVarP(&cfg.Log.Level, "log-level", "l", "info", "log level to use")
-	pflag.StringVar(&cfg.PeerDatabasePath, "peer-db", defaultPeerDB, "path to the database used for persisting peer data")
-	pflag.StringVar(&cfg.FunctionDatabasePath, "function-db", defaultFunctionDB, "path to the database used for persisting function data")
 
 	// Node configuration.
-	pflag.StringVarP(&cfg.Role, "role", "r", defaultRole, "role this note will have in the Blockless protocol (head or worker)")
-	pflag.StringVarP(&cfg.Host.Address, "address", "a", defaultAddress, "address that the b7s host will use")
-	pflag.UintVarP(&cfg.Host.Port, "port", "p", defaultPort, "port that the b7s host will use")
-
-	pflag.StringVarP(&cfg.Host.DialBackAddress, "dialback-address", "", defaultAddress, "external address that the b7s host will advertise")
-	pflag.UintVarP(&cfg.Host.DialBackPort, "dialback-port", "", defaultPort, "external port that the b7s host will advertise")
-
-	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the b7s host will use")
+	pflag.StringVar(&cfg.PeerDatabasePath, "peer-db", defaultPeerDB, "path to the database used for persisting peer data")
+	pflag.StringVar(&cfg.FunctionDatabasePath, "function-db", defaultFunctionDB, "path to the database used for persisting function data")
 	pflag.UintVarP(&cfg.Concurrency, "concurrency", "c", defaultConcurrency, "maximum number of requests node will process in parallel")
 	pflag.StringVar(&cfg.API, "rest-api", "", "address where the head node REST API will listen on")
-	pflag.StringSliceVar(&cfg.BootNodes, "boot-nodes", nil, "list of addresses that this node will connect to on startup, in multiaddr format")
-
 	pflag.StringVar(&cfg.Workspace, "workspace", "./workspace", "directory that the node can use for file storage")
 	pflag.StringVar(&cfg.Runtime, "runtime", "", "runtime address (used by the worker node)")
 
+	// Host configuration.
+	pflag.StringVarP(&cfg.Role, "role", "r", defaultRole, "role this note will have in the Blockless protocol (head or worker)")
+	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the b7s host will use")
+	pflag.StringVarP(&cfg.Host.Address, "address", "a", defaultAddress, "address that the b7s host will use")
+	pflag.UintVarP(&cfg.Host.Port, "port", "p", defaultPort, "port that the b7s host will use")
+	pflag.StringVarP(&cfg.Host.DialBackAddress, "dialback-address", "", defaultAddress, "external address that the b7s host will advertise")
+	pflag.UintVarP(&cfg.Host.DialBackPort, "dialback-port", "", defaultPort, "external port that the b7s host will advertise")
+	pflag.BoolVarP(&cfg.Host.Websocket, "websocket", "w", defaultUseWebsocket, "should the node use websocket protocol for communication")
+	pflag.StringSliceVar(&cfg.BootNodes, "boot-nodes", nil, "list of addresses that this node will connect to on startup, in multiaddr format")
+
+	// Limit configuration.
 	pflag.Float64Var(&cfg.CPUPercentage, "cpu-percentage-limit", 1.0, "amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited")
 	pflag.Int64Var(&cfg.MemoryMaxKB, "memory-limit", 0, "memory limit (kB) for Blockless Functions")
 

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -98,7 +98,9 @@ func run() int {
 		host.WithDialBackPeers(peerAddrs),
 		host.WithDialBackAddress(cfg.Host.DialBackAddress),
 		host.WithDialBackPort(cfg.Host.DialBackPort),
+		host.WithDialBackWebsocketPort(cfg.Host.DialBackWebsocketPort),
 		host.WithWebsocket(cfg.Host.Websocket),
+		host.WithWebsocketPort(cfg.Host.WebsocketPort),
 	)
 	if err != nil {
 		log.Error().Err(err).Str("key", cfg.Host.PrivateKey).Msg("could not create host")

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -98,6 +98,7 @@ func run() int {
 		host.WithDialBackPeers(peerAddrs),
 		host.WithDialBackAddress(cfg.Host.DialBackAddress),
 		host.WithDialBackPort(cfg.Host.DialBackPort),
+		host.WithWebsocket(cfg.Host.Websocket),
 	)
 	if err != nil {
 		log.Error().Err(err).Str("key", cfg.Host.PrivateKey).Msg("could not create host")

--- a/config/model.go
+++ b/config/model.go
@@ -21,12 +21,16 @@ type Config struct {
 
 // Host describes the libp2p host that the node will use.
 type Host struct {
-	Port            uint
-	Address         string
-	PrivateKey      string
-	DialBackPort    uint
-	DialBackAddress string
-	Websocket       bool
+	Port       uint
+	Address    string
+	PrivateKey string
+
+	DialBackPort          uint
+	DialBackAddress       string
+	DialBackWebsocketPort uint
+
+	Websocket     bool
+	WebsocketPort uint
 }
 
 // Log describes the logging configuration.

--- a/config/model.go
+++ b/config/model.go
@@ -26,6 +26,7 @@ type Host struct {
 	PrivateKey      string
 	DialBackPort    uint
 	DialBackAddress string
+	Websocket       bool
 }
 
 // Log describes the logging configuration.

--- a/host/config.go
+++ b/host/config.go
@@ -12,6 +12,7 @@ var defaultConfig = Config{
 	ConnectionThreshold: 20,
 	DialBackPeersLimit:  100,
 	DiscoveryInterval:   10 * time.Second,
+	Websocket:           false,
 }
 
 // Config represents the Host configuration.
@@ -24,6 +25,7 @@ type Config struct {
 	DiscoveryInterval   time.Duration
 	DialBackAddress     string
 	DialBackPort        uint
+	Websocket           bool
 }
 
 // WithPrivateKey specifies the private key for the Host.
@@ -77,5 +79,12 @@ func WithDialBackPeersLimit(n uint) func(*Config) {
 func WithDiscoveryInterval(d time.Duration) func(*Config) {
 	return func(cfg *Config) {
 		cfg.DiscoveryInterval = d
+	}
+}
+
+// WithWebsocket specifies whether libp2p host should use websocket protocol.
+func WithWebsocket(b bool) func(*Config) {
+	return func(cfg *Config) {
+		cfg.Websocket = b
 	}
 }

--- a/host/config.go
+++ b/host/config.go
@@ -17,15 +17,20 @@ var defaultConfig = Config{
 
 // Config represents the Host configuration.
 type Config struct {
-	PrivateKey          string
+	PrivateKey string
+
 	ConnectionThreshold uint
 	BootNodes           []multiaddr.Multiaddr
 	DialBackPeers       []multiaddr.Multiaddr
 	DialBackPeersLimit  uint
 	DiscoveryInterval   time.Duration
-	DialBackAddress     string
-	DialBackPort        uint
-	Websocket           bool
+
+	Websocket     bool
+	WebsocketPort uint
+
+	DialBackAddress       string
+	DialBackPort          uint
+	DialBackWebsocketPort uint
 }
 
 // WithPrivateKey specifies the private key for the Host.
@@ -68,6 +73,12 @@ func WithDialBackPort(n uint) func(*Config) {
 	}
 }
 
+func WithDialBackWebsocketPort(n uint) func(*Config) {
+	return func(cfg *Config) {
+		cfg.DialBackWebsocketPort = n
+	}
+}
+
 // WithDialBackPeersLimit specifies the maximum number of dial-back peers to use.
 func WithDialBackPeersLimit(n uint) func(*Config) {
 	return func(cfg *Config) {
@@ -86,5 +97,12 @@ func WithDiscoveryInterval(d time.Duration) func(*Config) {
 func WithWebsocket(b bool) func(*Config) {
 	return func(cfg *Config) {
 		cfg.Websocket = b
+	}
+}
+
+// WithWebsocketPort specifies on which port the host should listen for websocket connections.
+func WithWebsocketPort(port uint) func(*Config) {
+	return func(cfg *Config) {
+		cfg.WebsocketPort = port
 	}
 }

--- a/host/dht.go
+++ b/host/dht.go
@@ -55,7 +55,7 @@ findPeers:
 				continue
 			}
 
-			h.log.Info().Str("peer", peer.String()).Msg("connected to peer")
+			h.log.Info().Str("peer", peer.ID.String()).Msg("connected to peer")
 
 			connected++
 

--- a/host/host.go
+++ b/host/host.go
@@ -34,6 +34,12 @@ func New(log zerolog.Logger, address string, port uint, options ...func(*Config)
 	}
 
 	if cfg.Websocket {
+
+		// If the TCP and websocket port are explicitely chosen and set to the same value, one of the two listens will silently fail.
+		if port == cfg.WebsocketPort && cfg.WebsocketPort != 0 {
+			return nil, fmt.Errorf("TCP and websocket ports cannot be the same (TCP: %v, Websocket: %v)", port, cfg.WebsocketPort)
+		}
+
 		wsAddr := fmt.Sprintf("/ip4/%v/tcp/%v/ws", address, cfg.WebsocketPort)
 		addresses = append(addresses, wsAddr)
 	}
@@ -64,6 +70,11 @@ func New(log zerolog.Logger, address string, port uint, options ...func(*Config)
 		}
 
 		if cfg.Websocket && cfg.DialBackWebsocketPort != 0 {
+
+			if cfg.DialBackWebsocketPort == cfg.DialBackPort {
+				return nil, fmt.Errorf("TCP and websocket dialback ports cannot be the same (TCP: %v, Websocket: %v)", cfg.DialBackPort, cfg.DialBackWebsocketPort)
+			}
+
 			externalWsAddr := fmt.Sprintf("/ip4/%v/tcp/%v/ws", address, cfg.WebsocketPort)
 			extAddresses = append(extAddresses, externalWsAddr)
 		}

--- a/host/host.go
+++ b/host/host.go
@@ -34,7 +34,7 @@ func New(log zerolog.Logger, address string, port uint, options ...func(*Config)
 	}
 
 	if cfg.Websocket {
-		wsAddr := hostAddress + "/ws"
+		wsAddr := fmt.Sprintf("/ip4/%v/tcp/%v/ws", address, cfg.WebsocketPort)
 		addresses = append(addresses, wsAddr)
 	}
 
@@ -59,18 +59,18 @@ func New(log zerolog.Logger, address string, port uint, options ...func(*Config)
 	if cfg.DialBackAddress != "" && cfg.DialBackPort != 0 {
 
 		externalAddr := fmt.Sprintf("/ip4/%s/tcp/%d", cfg.DialBackAddress, cfg.DialBackPort)
-		addrs := []string{
+		extAddresses := []string{
 			externalAddr,
 		}
 
-		if cfg.Websocket {
-			externalWsAddr := externalAddr + "/ws"
-			addresses = append(addrs, externalWsAddr)
+		if cfg.Websocket && cfg.DialBackWebsocketPort != 0 {
+			externalWsAddr := fmt.Sprintf("/ip4/%v/tcp/%v/ws", address, cfg.WebsocketPort)
+			extAddresses = append(extAddresses, externalWsAddr)
 		}
 
 		// Create list of multiaddrs with the external IP and port.
 		var externalAddrs []ma.Multiaddr
-		for _, addr := range addresses {
+		for _, addr := range extAddresses {
 			maddr, err := ma.NewMultiaddr(addr)
 			if err != nil {
 				return nil, fmt.Errorf("could not create external multiaddress: %w", err)

--- a/node/notifiee.go
+++ b/node/notifiee.go
@@ -43,10 +43,12 @@ func (n *connectionNotifiee) Connected(network network.Network, conn network.Con
 func (n *connectionNotifiee) Disconnected(_ network.Network, conn network.Conn) {
 
 	// TODO: Check - do we want to remove peer after he's been disconnected.
+	maddr := conn.RemoteMultiaddr()
 
 	peerID := conn.RemotePeer()
 	n.log.Debug().
 		Str("peer", peerID.String()).
+		Str("addr", maddr.String()).
 		Msg("peer disconnected")
 }
 

--- a/node/notifiee.go
+++ b/node/notifiee.go
@@ -26,11 +26,13 @@ func (n *connectionNotifiee) Connected(network network.Network, conn network.Con
 	// Get peer information.
 	peerID := conn.RemotePeer()
 	maddr := conn.RemoteMultiaddr()
+	laddr := conn.LocalMultiaddr()
 	addrInfo := network.Peerstore().PeerInfo(peerID)
 
 	n.log.Debug().
 		Str("peer", peerID.String()).
-		Str("addr", maddr.String()).
+		Str("remote_address", maddr.String()).
+		Str("local_address", laddr.String()).
 		Msg("peer connected")
 
 	// Store the peer info.
@@ -44,11 +46,13 @@ func (n *connectionNotifiee) Disconnected(_ network.Network, conn network.Conn) 
 
 	// TODO: Check - do we want to remove peer after he's been disconnected.
 	maddr := conn.RemoteMultiaddr()
+	laddr := conn.LocalMultiaddr()
 
 	peerID := conn.RemotePeer()
 	n.log.Debug().
 		Str("peer", peerID.String()).
-		Str("addr", maddr.String()).
+		Str("remote_address", maddr.String()).
+		Str("local_address", laddr.String()).
 		Msg("peer disconnected")
 }
 


### PR DESCRIPTION
This PR adds support for opening up an additional port and listening on an additional multiaddress for a Websocket connection.
Due to the current implementation of the `libp2p` Websocket Transport - outbound Websocket connections will use a random port. For example, for TCP, if we listen on a port 9000, outbound connections from our node will also use the port 9000. If we listen for connections on port 9000 for Websocket connections, outbound connections will use a random port.

It doesn't seem possible to use the same TCP port for regular TCP connection and for Websocket connection. This is because the first of the two `listen` attempts will succeed, and the second one will fail because the port is already taken. Libp2p considers a `listen` successful if at least one attempts succeeds, so this will silently fail. Because of this, the connections use different ports.

NOTE: At the moment the Websocket connection is dropped after 10 seconds or so. This is in my test scenario where there's still little activity on the conn.. I suspect this is why the connection gets dropped; an implementation of periodic `ping` messages from the connecting party would keep the connection alive.  Will test to confirm. 