### PR TITLE
Roll call responses cleanup

### DIFF
--- a/node/execute.go
+++ b/node/execute.go
@@ -132,6 +132,10 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 		Int("quorum", quorum).
 		Msg("processing execution request")
 
+	// Create the queue to record roll call respones.
+	n.rollCall.create(requestID)
+	defer n.rollCall.remove(requestID)
+
 	err := n.issueRollCall(ctx, requestID, req.FunctionID)
 	if err != nil {
 		return codes.Error, nil, fmt.Errorf("could not issue roll call: %w", err)

--- a/node/handlers.go
+++ b/node/handlers.go
@@ -48,10 +48,14 @@ func (n *Node) processRollCallResponse(ctx context.Context, from peer.ID, payloa
 		return nil
 	}
 
-	n.log.Info().
-		Str("peer", from.String()).
-		Str("request_id", res.RequestID).
-		Msg("recording peers roll call response")
+	// Check if there's an active roll call already.
+	exists := n.rollCall.exists(res.RequestID)
+	if !exists {
+		n.log.Info().Str("peer", from.String()).Str("request_id", res.RequestID).Msg("no pending roll call for the given request, dropping response")
+		return nil
+	}
+
+	n.log.Info().Str("peer", from.String()).Str("request_id", res.RequestID).Msg("recording roll call response")
 
 	// Record the response.
 	n.rollCall.add(res.RequestID, res)

--- a/node/handlers_internal_test.go
+++ b/node/handlers_internal_test.go
@@ -41,6 +41,8 @@ func TestNode_Handlers(t *testing.T) {
 			requestID = "dummy-request-id"
 		)
 
+		node.rollCall.create(requestID)
+
 		res := response.RollCall{
 			Type:       blockless.MessageRollCallResponse,
 			Code:       codes.Accepted,

--- a/node/queue_test.go
+++ b/node/queue_test.go
@@ -1,0 +1,81 @@
+package node
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestRollCallQueue(t *testing.T) {
+
+	var (
+		requestID = "dummy-request-id"
+
+		res = response.RollCall{
+			Type:       blockless.MessageRollCallResponse,
+			From:       mocks.GenericPeerID,
+			RequestID:  requestID,
+			FunctionID: "dummy-function-id",
+		}
+	)
+
+	t.Run("roll call queue works", func(t *testing.T) {
+
+		const (
+			count = 20
+		)
+
+		queue := newQueue(100)
+
+		// Request does not exist in an empty map.
+		require.False(t, queue.exists(requestID))
+
+		// Request exists after creation.
+		queue.create(requestID)
+		require.True(t, queue.exists(requestID))
+
+		var wg sync.WaitGroup
+		wg.Add(count)
+		//  Add `count` responses in parallel.
+		for i := 0; i < count; i++ {
+			go func() {
+				defer wg.Done()
+				queue.add(requestID, res)
+			}()
+		}
+		wg.Wait()
+
+		// Verify we have all responses recorded.
+		responses := queue.responses(requestID)
+		require.Len(t, responses, count)
+
+		for i := 0; i < count; i++ {
+			r := <-responses
+			require.Equal(t, res, r)
+		}
+
+		queue.remove(requestID)
+		require.False(t, queue.exists(requestID))
+	})
+	t.Run("roll call with pending responses removal works", func(t *testing.T) {
+
+		const (
+			count = 5
+		)
+
+		queue := newQueue(100)
+		queue.create(requestID)
+
+		for i := 0; i < count; i++ {
+			queue.add(requestID, res)
+		}
+
+		queue.remove(requestID)
+		require.False(t, queue.exists(requestID))
+	})
+}


### PR DESCRIPTION
This PR introduces cleanup of roll call responses after they have served their purpose.

When a head node issues a roll call, we essentially create a small queue where we'll store all roll call responses for that execution request.
When the head node completes the execution for that request, we'll remove the queue we used for that execution request.
Any roll call responses we receive afterwards (or at any time) - for a request ID that does not have a pending roll call - we just drop.

