### PR TITLE
Use absolute path for workspace universally

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/labstack/echo/v4"
@@ -59,6 +60,14 @@ func run() int {
 		log.Error().Err(err).Str("role", cfg.Role).Msg("invalid node role specified")
 		return failure
 	}
+
+	// Convert workspace path to an absolute one.
+	workspace, err := filepath.Abs(cfg.Workspace)
+	if err != nil {
+		log.Error().Err(err).Str("path", cfg.Workspace).Msg("could not determine absolute path for workspace")
+		return failure
+	}
+	cfg.Workspace = workspace
 
 	// Open the pebble peer database.
 	pdb, err := pebble.Open(cfg.PeerDatabasePath, &pebble.Options{})


### PR DESCRIPTION
This PR tweaks handling of the `workspace` CLI argument; It's an inconsequential change more or less, where we now convert a (potential) relative path to an absolute one before passing it down to components (e.g. executor or fstore). Reason for the change is that `fstore` should use the absolute path for the workspace, but since it's a common theme we can just do it before creating the component(s).