### PR TITLE
Minor logging tweaks

### DIFF
--- a/api/execute.go
+++ b/api/execute.go
@@ -46,7 +46,7 @@ func (a *API) Execute(ctx echo.Context) error {
 	// Get the execution result.
 	code, id, results, cluster, err := a.node.ExecuteFunction(ctx.Request().Context(), execute.Request(req))
 	if err != nil {
-		a.log.Warn().Str("function_id", req.FunctionID).Err(err).Msg("node failed to execute function")
+		a.log.Warn().Str("function", req.FunctionID).Err(err).Msg("node failed to execute function")
 	}
 
 	// Transform the node response format to the one returned by the API.

--- a/node/cluster.go
+++ b/node/cluster.go
@@ -24,7 +24,7 @@ func (n *Node) processFormCluster(ctx context.Context, from peer.ID, payload []b
 	}
 	req.From = from
 
-	n.log.Info().Str("request_id", req.RequestID).Strs("peers", peerIDList(req.Peers)).Msg("received request to form consensus cluster")
+	n.log.Info().Str("request", req.RequestID).Strs("peers", peerIDList(req.Peers)).Msg("received request to form consensus cluster")
 
 	raftHandler, err := n.newRaftHandler(req.RequestID)
 	if err != nil {
@@ -92,7 +92,7 @@ func (n *Node) processFormClusterResponse(ctx context.Context, from peer.ID, pay
 	}
 	res.From = from
 
-	n.log.Debug().Str("request_id", res.RequestID).Str("from", from.String()).Msg("received cluster formation response")
+	n.log.Debug().Str("request", res.RequestID).Str("from", from.String()).Msg("received cluster formation response")
 
 	key := consensusResponseKey(res.RequestID, from)
 	n.consensusResponses.Set(key, res)
@@ -111,11 +111,11 @@ func (n *Node) processDisbandCluster(ctx context.Context, from peer.ID, payload 
 	}
 	req.From = from
 
-	n.log.Info().Str("request_id", req.RequestID).Msg("received request to disband consensus cluster")
+	n.log.Info().Str("request", req.RequestID).Msg("received request to disband consensus cluster")
 
 	err = n.leaveCluster(req.RequestID)
 	if err != nil {
-		return fmt.Errorf("could not disband cluster (request_id: %s): %w", req.RequestID, err)
+		return fmt.Errorf("could not disband cluster (request: %s): %w", req.RequestID, err)
 	}
 
 	return nil
@@ -129,11 +129,11 @@ func (n *Node) leaveCluster(requestID string) error {
 	// We know that the request is done executing when we have a result for it.
 	_, ok := n.executeResponses.WaitFor(ctx, requestID)
 
-	n.log.Info().Bool("executed_work", ok).Str("request_id", requestID).Msg("waiting for execution done, leaving raft cluster")
+	n.log.Info().Bool("executed_work", ok).Str("request", requestID).Msg("waiting for execution done, leaving raft cluster")
 
 	err := n.shutdownCluster(requestID)
 	if err != nil {
-		return fmt.Errorf("could not leave raft cluster (request_id: %v): %w", requestID, err)
+		return fmt.Errorf("could not leave raft cluster (request: %v): %w", requestID, err)
 	}
 
 	return nil

--- a/node/execute.go
+++ b/node/execute.go
@@ -30,10 +30,7 @@ func (n *Node) processExecuteResponse(ctx context.Context, from peer.ID, payload
 	}
 	res.From = from
 
-	n.log.Debug().
-		Str("request_id", res.RequestID).
-		Str("from", from.String()).
-		Msg("received execution response")
+	n.log.Debug().Str("request", res.RequestID).Str("from", from.String()).Msg("received execution response")
 
 	key := executionResultKey(res.RequestID, from)
 	n.executeResponses.Set(key, res)

--- a/node/fsm.go
+++ b/node/fsm.go
@@ -53,7 +53,7 @@ func (f fsmExecutor) Apply(log *raft.Log) interface{} {
 		return fmt.Errorf("could not unmarshal request: %w", err)
 	}
 
-	f.log.Info().Str("request_id", logEntry.RequestID).Str("function_id", logEntry.Execute.FunctionID).Msg("FSM executing function")
+	f.log.Info().Str("request", logEntry.RequestID).Str("function", logEntry.Execute.FunctionID).Msg("FSM executing function")
 
 	res, err := f.executor.ExecuteFunction(logEntry.RequestID, logEntry.Execute)
 	if err != nil {
@@ -65,7 +65,7 @@ func (f fsmExecutor) Apply(log *raft.Log) interface{} {
 		proc(logEntry, res)
 	}
 
-	f.log.Info().Msg("log entry successfully applied")
+	f.log.Info().Str("request", logEntry.RequestID).Msg("FSM successfully executed function")
 
 	return res
 }

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -135,7 +135,7 @@ rollCallResponseLoop:
 		}
 	}
 
-	n.log.Info().Strs("peers", peerIDList(reportingPeers)).Msg("requesting cluster formation from peers who reported for roll call")
+	log.Info().Strs("peers", peerIDList(reportingPeers)).Msg("requesting cluster formation from peers who reported for roll call")
 
 	cluster := execute.Cluster{
 		Peers: reportingPeers,
@@ -178,6 +178,7 @@ rollCallResponseLoop:
 			err = n.sendToMany(ctx, reportingPeers, msgDisband)
 			if err != nil {
 				log.Error().Err(err).Strs("peers", peerIDList(reportingPeers)).Msg("could not send cluster disband request")
+				return
 			}
 
 			log.Error().Err(err).Strs("peers", peerIDList(reportingPeers)).Msg("sent cluster disband request")
@@ -206,7 +207,7 @@ rollCallResponseLoop:
 				return
 			}
 
-			log.Debug().Str("peer", rp.String()).Msg("accounted consensus response from roll called peer")
+			log.Info().Str("peer", rp.String()).Msg("accounted consensus response from roll called peer")
 
 			fc := res.(response.FormCluster)
 			if fc.Code != codes.OK {
@@ -271,7 +272,7 @@ rollCallResponseLoop:
 				return
 			}
 
-			log.Debug().Str("peer", rp.String()).Msg("accounted execution response from peer")
+			log.Info().Str("peer", rp.String()).Msg("accounted execution response from peer")
 
 			er := res.(response.Execute)
 

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -31,17 +31,14 @@ func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []b
 		return fmt.Errorf("could not generate new request ID: %w", err)
 	}
 
+	log := n.log.With().Str("request", req.RequestID).Str("peer", from.String()).Str("function", req.FunctionID).Logger()
+
 	code, results, cluster, err := n.headExecute(ctx, requestID, createExecuteRequest(req))
 	if err != nil {
-		n.log.Error().
-			Err(err).
-			Str("peer", from.String()).
-			Str("function_id", req.FunctionID).
-			Str("request_id", requestID).
-			Msg("execution failed")
+		log.Error().Err(err).Msg("execution failed")
 	}
 
-	n.log.Info().Str("request_id", requestID).Str("code", code.String()).Msg("execution complete")
+	log.Info().Str("code", code.String()).Msg("execution complete")
 
 	// NOTE: Head node no longer caches execution results because it doesn't have one of its own.
 
@@ -78,7 +75,10 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 		quorum = req.Config.NodeCount
 	}
 
-	n.log.Info().Str("request_id", requestID).Int("quorum", quorum).Msg("processing execution request")
+	// Create a logger with relevant context.
+	log := n.log.With().Str("request", requestID).Str("function", req.FunctionID).Int("quorum", quorum).Logger()
+
+	log.Info().Msg("processing execution request")
 
 	// Phase 1. - Issue roll call to nodes.
 
@@ -92,7 +92,7 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 		return codes.Error, nil, execute.Cluster{}, fmt.Errorf("could not issue roll call: %w", err)
 	}
 
-	n.log.Info().Str("function_id", req.FunctionID).Str("request_id", requestID).Msg("roll call published")
+	log.Info().Msg("roll call published")
 
 	// Limit for how long we wait for responses.
 	tctx, exCancel := context.WithTimeout(ctx, n.cfg.RollCallTimeout)
@@ -107,35 +107,35 @@ rollCallResponseLoop:
 		// Request timed out.
 		case <-tctx.Done():
 
-			n.log.Warn().Str("function_id", req.FunctionID).Str("request_id", requestID).Msg("roll call timed out")
+			log.Warn().Msg("roll call timed out")
 			return codes.Timeout, nil, execute.Cluster{}, blockless.ErrRollCallTimeout
 
 		case reply := <-n.rollCall.responses(requestID):
 
 			// Check if this is the reply we want - shouldn't really happen.
 			if reply.FunctionID != req.FunctionID {
-				n.log.Info().Str("peer", reply.From.String()).Str("request_id", requestID).Str("function_got", reply.FunctionID).Str("function_want", req.FunctionID).Msg("skipping inadequate roll call response - wrong function")
+				log.Info().Str("peer", reply.From.String()).Str("function_got", reply.FunctionID).Msg("skipping inadequate roll call response - wrong function")
 				continue
 			}
 
 			// Check if we are connected to this peer.
 			// Since we receive responses to roll call via direct messages - should not happen.
 			if !n.haveConnection(reply.From) {
-				n.log.Info().Str("peer", reply.From.String()).Str("request_id", reply.RequestID).Msg("skipping roll call response from unconnected peer")
+				n.log.Info().Str("peer", reply.From.String()).Msg("skipping roll call response from unconnected peer")
 				continue
 			}
 
-			n.log.Info().Str("request_id", requestID).Str("peer", reply.From.String()).Int("want_peers", quorum).Msg("roll called peer chosen for execution")
+			log.Info().Str("peer", reply.From.String()).Msg("roll called peer chosen for execution")
 
 			reportingPeers = append(reportingPeers, reply.From)
 			if len(reportingPeers) >= quorum {
-				n.log.Info().Str("request_id", requestID).Int("want", quorum).Msg("enough peers reported for roll call")
+				log.Info().Msg("enough peers reported for roll call")
 				break rollCallResponseLoop
 			}
 		}
 	}
 
-	n.log.Info().Strs("peers", peerIDList(reportingPeers)).Str("function_id", req.FunctionID).Str("request_id", requestID).Msg("requesting cluster formation from peers who reported for roll call")
+	n.log.Info().Strs("peers", peerIDList(reportingPeers)).Msg("requesting cluster formation from peers who reported for roll call")
 
 	cluster := execute.Cluster{
 		Peers: reportingPeers,
@@ -157,7 +157,7 @@ rollCallResponseLoop:
 	}
 
 	// Wait for cluster confirmation messages.
-	n.log.Debug().Int("want", quorum).Str("request_id", requestID).Msg("waiting for cluster to be formed")
+	log.Debug().Msg("waiting for cluster to be formed")
 
 	// When we're done, send a message to disband the cluster.
 	// NOTE: We could schedule this on the worker nodes when receiving the execution request.
@@ -177,10 +177,10 @@ rollCallResponseLoop:
 
 			err = n.sendToMany(ctx, reportingPeers, msgDisband)
 			if err != nil {
-				n.log.Error().Err(err).Strs("peers", peerIDList(reportingPeers)).Str("request_id", requestID).Msg("could not send cluster disband request")
+				log.Error().Err(err).Strs("peers", peerIDList(reportingPeers)).Msg("could not send cluster disband request")
 			}
 
-			n.log.Error().Err(err).Strs("peers", peerIDList(reportingPeers)).Str("request_id", requestID).Msg("sent cluster disband request")
+			log.Error().Err(err).Strs("peers", peerIDList(reportingPeers)).Msg("sent cluster disband request")
 		}()
 	}()
 
@@ -206,11 +206,11 @@ rollCallResponseLoop:
 				return
 			}
 
-			n.log.Debug().Str("request_id", requestID).Str("peer", rp.String()).Msg("accounted consensus response from roll called peer")
+			log.Debug().Str("peer", rp.String()).Msg("accounted consensus response from roll called peer")
 
 			fc := res.(response.FormCluster)
 			if fc.Code != codes.OK {
-				n.log.Debug().Str("request_id", requestID).Str("peer", rp.String()).Msg("peer failed to join consensus cluster")
+				log.Warn().Str("peer", rp.String()).Msg("peer failed to join consensus cluster")
 				return
 			}
 
@@ -244,7 +244,7 @@ rollCallResponseLoop:
 		return codes.Error, nil, cluster, fmt.Errorf("could not send execution request to peers (function: %s, request: %s): %w", req.FunctionID, requestID, err)
 	}
 
-	n.log.Debug().Int("want", quorum).Str("request_id", requestID).Msg("waiting for execution responses")
+	log.Debug().Msg("waiting for execution responses")
 
 	// We're willing to wait for a limited amount of time.
 	exctx, exCancel := context.WithTimeout(ctx, n.cfg.ExecutionTimeout)
@@ -271,7 +271,7 @@ rollCallResponseLoop:
 				return
 			}
 
-			n.log.Debug().Str("request_id", requestID).Str("peer", rp.String()).Msg("accounted execution response from peer")
+			log.Debug().Str("peer", rp.String()).Msg("accounted execution response from peer")
 
 			er := res.(response.Execute)
 
@@ -288,7 +288,7 @@ rollCallResponseLoop:
 
 	wg.Wait()
 
-	n.log.Info().Str("request_id", requestID).Int("cluster_size", len(reportingPeers)).Int("responded", len(results)).Msg("received execution responses")
+	log.Info().Int("cluster_size", len(reportingPeers)).Int("responded", len(results)).Msg("received execution responses")
 
 	// How many results do we have, and how many do we expect.
 	respondRatio := float64(len(results)) / float64(len(reportingPeers))
@@ -296,7 +296,7 @@ rollCallResponseLoop:
 
 	retcode := codes.OK
 	if respondRatio < threshold {
-		n.log.Warn().Str("request_id", requestID).Float64("expected", threshold).Float64("have", respondRatio).Msg("threshold condition not met")
+		log.Warn().Float64("expected", threshold).Float64("have", respondRatio).Msg("threshold condition not met")
 		retcode = codes.PartialContent
 	}
 

--- a/node/install.go
+++ b/node/install.go
@@ -17,8 +17,7 @@ func (n *Node) processInstallFunction(ctx context.Context, from peer.ID, payload
 
 	// Only workers should respond to function install requests.
 	if n.cfg.Role != blockless.WorkerNode {
-		n.log.Debug().
-			Msg("received function install request, ignoring")
+		n.log.Debug().Msg("received function install request, ignoring")
 		return nil
 	}
 

--- a/node/message.go
+++ b/node/message.go
@@ -77,9 +77,5 @@ func (n *Node) publish(ctx context.Context, msg interface{}) error {
 
 func (n *Node) haveConnection(peer peer.ID) bool {
 	connections := n.host.Network().ConnsToPeer(peer)
-	if len(connections) > 0 {
-		return true
-	}
-
-	return false
+	return len(connections) > 0
 }

--- a/node/raft.go
+++ b/node/raft.go
@@ -153,7 +153,8 @@ func bootstrapCluster(raftHandler *raftHandler, peerIDs []peer.ID) error {
 
 func (n *Node) shutdownCluster(requestID string) error {
 
-	n.log.Info().Str("request_id", requestID).Msg("shutting down cluster")
+	log := n.log.With().Str("request", requestID).Logger()
+	log.Info().Msg("shutting down cluster")
 
 	n.clusterLock.RLock()
 	raftHandler, ok := n.clusters[requestID]
@@ -173,13 +174,13 @@ func (n *Node) shutdownCluster(requestID string) error {
 	var retErr error
 	err = raftHandler.log.Close()
 	if err != nil {
-		n.log.Error().Err(err).Str("request_id", requestID).Msg("could not close log store")
+		log.Error().Err(err).Msg("could not close log store")
 		retErr = fmt.Errorf("could not close raft database")
 	}
 
 	err = raftHandler.stable.Close()
 	if err != nil {
-		n.log.Error().Err(err).Str("request_id", requestID).Msg("could not close stable store")
+		log.Error().Err(err).Msg("could not close stable store")
 		retErr = fmt.Errorf("could not close raft database")
 	}
 
@@ -187,7 +188,7 @@ func (n *Node) shutdownCluster(requestID string) error {
 	dir := n.consensusDir(requestID)
 	err = os.RemoveAll(dir)
 	if err != nil {
-		n.log.Error().Err(err).Str("request_id", requestID).Str("path", dir).Msg("could not delete consensus dir")
+		log.Error().Err(err).Str("path", dir).Msg("could not delete consensus dir")
 		retErr = fmt.Errorf("could not delete consensus directory")
 	}
 

--- a/node/rest.go
+++ b/node/rest.go
@@ -25,7 +25,7 @@ func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request) (codes.
 
 	code, results, cluster, err := n.headExecute(ctx, requestID, req)
 	if err != nil {
-		n.log.Error().Str("request_id", requestID).Err(err).Msg("execution failed")
+		n.log.Error().Str("request", requestID).Err(err).Msg("execution failed")
 	}
 
 	return code, requestID, results, cluster, nil
@@ -51,10 +51,7 @@ func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid strin
 		req = createInstallMessageFromCID(cid)
 	}
 
-	n.log.Debug().
-		Str("url", req.ManifestURL).
-		Str("cid", req.CID).
-		Msg("publishing function install message")
+	n.log.Debug().Str("url", req.ManifestURL).Str("cid", req.CID).Msg("publishing function install message")
 
 	err := n.publish(ctx, req)
 	if err != nil {

--- a/node/run.go
+++ b/node/run.go
@@ -33,9 +33,7 @@ func (n *Node) Run(ctx context.Context) error {
 	go func() {
 		err = n.host.DiscoverPeers(ctx, n.cfg.Topic)
 		if err != nil {
-			n.log.Error().
-				Err(err).
-				Msg("could not discover peers")
+			n.log.Error().Err(err).Msg("could not discover peers")
 		}
 	}()
 
@@ -45,9 +43,7 @@ func (n *Node) Run(ctx context.Context) error {
 	// Start the function sync in the background to periodically check functions.
 	go n.runSyncLoop(ctx)
 
-	n.log.Info().
-		Uint("concurrency", n.cfg.Concurrency).
-		Msg("starting node main loop")
+	n.log.Info().Uint("concurrency", n.cfg.Concurrency).Msg("starting node main loop")
 
 	// Message processing loop.
 	for {
@@ -65,7 +61,7 @@ func (n *Node) Run(ctx context.Context) error {
 			continue
 		}
 
-		n.log.Trace().Str("message_id", msg.ID).Str("peer_id", msg.ReceivedFrom.String()).Msg("received message")
+		n.log.Trace().Str("id", msg.ID).Str("peer", msg.ReceivedFrom.String()).Msg("received message")
 
 		// Try to get a slot for processing the request.
 		n.sema <- struct{}{}
@@ -106,11 +102,11 @@ func (n *Node) listenDirectMessages(ctx context.Context) {
 			return
 		}
 
-		n.log.Debug().Str("peer_id", from.String()).Msg("received direct message")
+		n.log.Debug().Str("peer", from.String()).Msg("received direct message")
 
 		err = n.processMessage(ctx, from, msg)
 		if err != nil {
-			n.log.Error().Err(err).Str("peer_id", from.String()).Msg("could not process direct message")
+			n.log.Error().Err(err).Str("peer", from.String()).Msg("could not process direct message")
 		}
 	})
 }

--- a/node/sync.go
+++ b/node/sync.go
@@ -19,7 +19,7 @@ func (n *Node) syncFunctions() {
 			continue
 		}
 
-		n.log.Debug().Str("cid", cid).Msg("function sync ok")
+		n.log.Debug().Str("function", cid).Msg("function sync ok")
 	}
 }
 


### PR DESCRIPTION
This PR makes slight changes to logging in certain areas - if we log some fields multiple times over a course of a function, we just create a temporary sublogger. This is frequent for execution requests where we may log the `requestID` or `functionID` on each log message.