### PR TITLE
[WIP] Basic skeleton for PBFT consensus

### DIFF
--- a/consensus/pbft/commit.go
+++ b/consensus/pbft/commit.go
@@ -1,0 +1,128 @@
+package pbft
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// TODO (pbft): Split into `shouldSendCommit` and `sendCommit`.
+func (r *Replica) maybeSendCommit(view uint, sequenceNo uint, digest string) error {
+
+	log := r.log.With().Uint("view", view).Uint("sequence_number", sequenceNo).Str("digest", digest).Logger()
+
+	if !r.prepared(view, sequenceNo, digest) {
+		log.Info().Msg("request not yet prepared, not committing")
+		return nil
+	}
+
+	// Have we already sent a commit message?
+	msgID := getMessageID(view, sequenceNo)
+	commits, ok := r.commits[msgID]
+	if ok {
+		_, sent := commits.m[r.id]
+		if sent {
+			log.Info().Msg("already have broadcast commit for this request, stopping now")
+			return nil
+		}
+	}
+
+	log.Info().Msg("request prepared, broadcasting commit")
+
+	err := r.sendCommit(view, sequenceNo, digest)
+	if err != nil {
+		return fmt.Errorf("could not send commit message: %w", err)
+	}
+
+	// TODO (pbft): This function does too much, split.
+	if !r.committed(view, sequenceNo, digest) {
+		log.Info().Msg("request is not yet committed")
+		return nil
+	}
+
+	err = r.execute(digest)
+	if err != nil {
+		return fmt.Errorf("request execution failed: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Replica) sendCommit(view uint, sequenceNo uint, digest string) error {
+
+	log := r.log.With().Uint("view", view).Uint("sequence_number", sequenceNo).Str("digest", digest).Logger()
+
+	log.Info().Msg("broadcasting commit message")
+
+	commit := Commit{
+		View:           view,
+		SequenceNumber: sequenceNo,
+		Digest:         digest,
+	}
+
+	err := r.broadcast(commit)
+	if err != nil {
+		return fmt.Errorf("could not broadcast commit message: %w", err)
+	}
+
+	log.Info().Msg("commit message successfully broadcast")
+
+	// Record this commit message.
+	r.recordCommitReceipt(r.id, commit)
+
+	return nil
+}
+
+func (r *Replica) processCommit(replica peer.ID, commit Commit) error {
+
+	log := r.log.With().Str("replica", replica.String()).Uint("view", commit.View).Uint("sequence_no", commit.SequenceNumber).Str("digest", commit.Digest).Logger()
+
+	log.Info().Msg("received commit message")
+
+	msgID := getMessageID(commit.View, commit.SequenceNumber)
+	commits, ok := r.commits[msgID]
+	if !ok {
+		r.commits[msgID] = newCommitReceipts()
+		commits = r.commits[msgID]
+	}
+
+	commits.Lock()
+	defer commits.Unlock()
+
+	// Have we already seen this commit?
+	_, seen := commits.m[replica]
+	if seen {
+		log.Warn().Msg("ignoring duplicate commit")
+		return nil
+	}
+
+	// Save this commit.
+	commits.m[replica] = commit
+
+	if !r.committed(commit.View, commit.SequenceNumber, commit.Digest) {
+		log.Info().Msg("request is not yet committed")
+		return nil
+	}
+
+	err := r.execute(commit.Digest)
+	if err != nil {
+		return fmt.Errorf("request execution failed: %w", err)
+
+	}
+
+	return nil
+}
+
+func (r *Replica) recordCommitReceipt(replica peer.ID, commit Commit) {
+
+	msgID := getMessageID(commit.View, commit.SequenceNumber)
+	commits, ok := r.commits[msgID]
+	if !ok {
+		r.commits[msgID] = newCommitReceipts()
+		commits = r.commits[msgID]
+	}
+
+	commits.Lock()
+	defer commits.Unlock()
+	commits.m[replica] = commit
+}

--- a/consensus/pbft/commit.go
+++ b/consensus/pbft/commit.go
@@ -40,12 +40,9 @@ func (r *Replica) maybeSendCommit(view uint, sequenceNo uint, digest string) err
 		return nil
 	}
 
-	err = r.execute(digest)
-	if err != nil {
-		return fmt.Errorf("request execution failed: %w", err)
-	}
+	log.Info().Msg("request committed, executing")
 
-	return nil
+	return r.execute(digest)
 }
 
 func (r *Replica) sendCommit(view uint, sequenceNo uint, digest string) error {

--- a/consensus/pbft/commit.go
+++ b/consensus/pbft/commit.go
@@ -76,6 +76,10 @@ func (r *Replica) processCommit(replica peer.ID, commit Commit) error {
 
 	log.Info().Msg("received commit message")
 
+	if commit.View != r.view {
+		return fmt.Errorf("commit has an invalid view value (received: %v, current: %v)", commit.View, r.view)
+	}
+
 	msgID := getMessageID(commit.View, commit.SequenceNumber)
 	commits, ok := r.commits[msgID]
 	if !ok {

--- a/consensus/pbft/conditions.go
+++ b/consensus/pbft/conditions.go
@@ -27,14 +27,14 @@ func (r *Replica) prePrepared(view uint, sequenceNo uint, digest string) bool {
 
 func (r *Replica) prepared(view uint, sequenceNo uint, digest string) bool {
 
-	// Have we seen this request before?
+	// Check if we have seen this request before.
 	// NOTE: This is also checked as part of the pre-prepare check.
 	_, seen := r.requests[digest]
 	if !seen {
 		return false
 	}
 
-	// Do we have a pre-prepare for this request?
+	// Is the pre-prepare condition met for this request?
 	if !r.prePrepared(view, sequenceNo, digest) {
 		return false
 	}

--- a/consensus/pbft/conditions.go
+++ b/consensus/pbft/conditions.go
@@ -1,0 +1,77 @@
+package pbft
+
+func (r *Replica) prePrepared(view uint, sequenceNo uint, digest string) bool {
+
+	if digest == "" {
+		return false
+	}
+
+	// Have we seen this request before?
+	_, seen := r.requests[digest]
+	if !seen {
+		return false
+	}
+
+	// Do we have a pre-prepare for this request?
+	preprepare, seen := r.preprepares[getMessageID(view, sequenceNo)]
+	if !seen {
+		return false
+	}
+
+	if preprepare.Digest != digest {
+		return false
+	}
+
+	return true
+}
+
+func (r *Replica) prepared(view uint, sequenceNo uint, digest string) bool {
+
+	// Have we seen this request before?
+	// NOTE: This is also checked as part of the pre-prepare check.
+	_, seen := r.requests[digest]
+	if !seen {
+		return false
+	}
+
+	// Do we have a pre-prepare for this request?
+	if !r.prePrepared(view, sequenceNo, digest) {
+		return false
+	}
+
+	prepares, ok := r.prepares[getMessageID(view, sequenceNo)]
+	if !ok {
+		return false
+	}
+
+	prepareCount := uint(len(prepares.m))
+	haveQuorum := prepareCount >= r.prepareQuorum()
+
+	r.log.Debug().Str("digest", digest).Uint("view", view).Uint("sequence_no", sequenceNo).
+		Uint("quorum", prepareCount).Bool("have_quorum", haveQuorum).
+		Msg("number of prepares for a request")
+
+	return haveQuorum
+}
+
+func (r *Replica) committed(view uint, sequenceNo uint, digest string) bool {
+
+	// Is the prepare condition met for this request?
+	if !r.prepared(view, sequenceNo, digest) {
+		return false
+	}
+
+	commits, ok := r.commits[getMessageID(view, sequenceNo)]
+	if !ok {
+		return false
+	}
+
+	commitCount := uint(len(commits.m))
+	haveQuorum := commitCount > r.commitQuorum()
+
+	r.log.Debug().Str("digest", digest).Uint("view", view).Uint("sequence_no", sequenceNo).
+		Uint("quorum", commitCount).Bool("have_quorum", haveQuorum).
+		Msg("number of commits for a request")
+
+	return haveQuorum
+}

--- a/consensus/pbft/core.go
+++ b/consensus/pbft/core.go
@@ -1,0 +1,69 @@
+package pbft
+
+type pbftCore struct {
+	// Number of replicas in the cluster.
+	n uint
+
+	// Number of byzantine replicas we can tolerate.
+	f uint
+
+	// Sequence number.
+	sequence uint
+
+	// ViewNumber.
+	view uint
+}
+
+func newPbftCore(total uint) pbftCore {
+
+	return pbftCore{
+		sequence: 0,
+		view:     0,
+		n:        total,
+		f:        calcByzantineTolerance(total),
+	}
+}
+
+// given a view number, return the index of the expected primary.
+func (c pbftCore) primary(v uint) uint {
+	return v % c.n
+}
+
+// return the index of the expected primary for the current view.
+func (c pbftCore) currentPrimary() uint {
+	return c.view % c.n
+}
+
+// TODO (pbft): are there different quorums? this one is for the prepare messages.
+func (c pbftCore) prepareQuorum() uint {
+	// TODO (pbft): Check if we should use 2f here or, as in fabric - (n+f+2)/2?
+	return 2 * c.f
+}
+
+func (c pbftCore) commitQuorum() uint {
+	return 2 * c.f
+}
+
+// based on the number of replicas, determine how many byzantine replicas we can tolerate.
+func calcByzantineTolerance(n uint) uint {
+
+	if n <= 1 {
+		return 0
+	}
+
+	f := (n - 1) / 3
+	return f
+}
+
+// messageID is used to identify a specific point in time as view + sequence number combination.
+type messageID struct {
+	view     uint
+	sequence uint
+}
+
+func getMessageID(view uint, sequenceNo uint) messageID {
+	return messageID{
+		view:     view,
+		sequence: sequenceNo,
+	}
+}

--- a/consensus/pbft/digest.go
+++ b/consensus/pbft/digest.go
@@ -1,0 +1,19 @@
+package pbft
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+func getDigest(req Request) string {
+	payload, _ := json.Marshal(req)
+	hash := sha256.Sum256(payload)
+
+	return hex.EncodeToString(hash[:])
+}
+
+func digestOK(req Request, digest string) bool {
+	d := getDigest(req)
+	return d == digest
+}

--- a/consensus/pbft/execute.go
+++ b/consensus/pbft/execute.go
@@ -1,12 +1,49 @@
 package pbft
 
+import (
+	"fmt"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetworking/b7s/models/response"
+)
+
+// execute executes the request AND sends the result back to origin.
 func (r *Replica) execute(digest string) error {
+
+	// Sanity check, should not happen.
+	request, ok := r.requests[digest]
+	if !ok {
+		return fmt.Errorf("unknown request (digest: %s)", digest)
+	}
+
+	log := r.log.With().Str("digest", digest).Str("request", request.ID).Logger()
 
 	// Remove this request from the list of outstanding requests.
 	delete(r.pending, digest)
 
-	// TODO (pbft): Implement.
-	r.log.Warn().Str("digest", digest).Msg("executing the request")
+	log.Info().Msg("executing request")
+
+	res, err := r.executor.ExecuteFunction(request.ID, request.Execute)
+	if err != nil {
+		log.Error().Err(err).Msg("execution failed")
+	}
+
+	log.Info().Msg("executed request")
+
+	msg := response.Execute{
+		Type:      blockless.MessageExecuteResponse,
+		Code:      res.Code,
+		RequestID: request.ID,
+		Results: execute.ResultMap{
+			r.id: res,
+		},
+	}
+
+	err = r.send(request.Origin, msg)
+	if err != nil {
+		return fmt.Errorf("could not send execution response to node (target: %s, request: %s): %w", request.Origin.String(), request.ID, err)
+	}
 
 	return nil
 }

--- a/consensus/pbft/execute.go
+++ b/consensus/pbft/execute.go
@@ -1,0 +1,12 @@
+package pbft
+
+func (r *Replica) execute(digest string) error {
+
+	// Remove this request from the list of outstanding requests.
+	delete(r.pending, digest)
+
+	// TODO (pbft): Implement.
+	r.log.Warn().Str("digest", digest).Msg("executing the request")
+
+	return nil
+}

--- a/consensus/pbft/executor.go
+++ b/consensus/pbft/executor.go
@@ -1,0 +1,9 @@
+package pbft
+
+import (
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+type Executor interface {
+	ExecuteFunction(requestID string, req execute.Request) (execute.Result, error)
+}

--- a/consensus/pbft/message.go
+++ b/consensus/pbft/message.go
@@ -1,0 +1,153 @@
+package pbft
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetworking/b7s/models/execute"
+)
+
+type MessageType uint
+
+const (
+	MessageRequest MessageType = iota + 1
+	MessagePrePrepare
+	MessagePrepare
+	MessageCommit
+)
+
+func (m MessageType) String() string {
+	switch m {
+	case MessagePrePrepare:
+		return "MessagePrePrepare"
+	case MessagePrepare:
+		return "MessagePrepare"
+	case MessageCommit:
+		return "MessageCommit"
+	default:
+		return fmt.Sprintf("unknown: %d", m)
+	}
+}
+
+type Request struct {
+	Timestamp time.Time `json:"timestamp"`
+	// TODO: Comes from the client, add relevant stuff here. Rethink this model.
+	Execute execute.Request `json:"execute"`
+}
+
+// TODO: In fabric code, all messages have a `replicaID` field.
+
+type PrePrepare struct {
+	View           uint    `json:"view"`
+	SequenceNumber uint    `json:"sequence_number"`
+	Digest         string  `json:"digest"`
+	Request        Request `json:"request"`
+	ReplicaID      peer.ID `json:"replica"`
+}
+
+func (p PrePrepare) MarshalJSON() ([]byte, error) {
+
+	// Define an alias without the JSON marshaller.
+	type alias PrePrepare
+	return json.Marshal(
+		struct {
+			Type MessageType `json:"type"`
+			Data alias       `json:"data"`
+		}{
+			Type: MessagePrePrepare,
+			Data: alias(p),
+		})
+}
+
+type Prepare struct {
+	View           uint    `json:"view"`
+	SequenceNumber uint    `json:"sequence_number"`
+	Digest         string  `json:"digest"`
+	ReplicaID      peer.ID `json:"replica"`
+}
+
+func (p Prepare) MarshalJSON() ([]byte, error) {
+	type alias Prepare
+	return json.Marshal(
+		struct {
+			Type MessageType `json:"type"`
+			Data alias       `json:"data"`
+		}{
+			Type: MessagePrepare,
+			Data: alias(p),
+		})
+}
+
+type Commit struct {
+	View           uint    `json:"view"`
+	SequenceNumber uint    `json:"sequence_number"`
+	Digest         string  `json:"digest"`
+	ReplicaID      peer.ID `json:"replica"`
+}
+
+func (c Commit) MarshalJSON() ([]byte, error) {
+	type alias Commit
+	return json.Marshal(
+		struct {
+			Type MessageType `json:"type"`
+			Data alias       `json:"data"`
+		}{
+			Type: MessageCommit,
+			Data: alias(c),
+		})
+}
+
+// messageRecord is used as an interim format to supplement the original type with its type.
+// Useful for serialization to automatically include the message type field.
+type messageRecord struct {
+	Type MessageType     `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+func unpackMessage(payload []byte) (any, error) {
+
+	var msg messageRecord
+	err := json.Unmarshal(payload, &msg)
+	if err != nil {
+		return nil, fmt.Errorf("could not unpack base message: %w", err)
+	}
+
+	switch msg.Type {
+	case MessageRequest:
+		var request Request
+		err = json.Unmarshal(msg.Data, &request)
+		if err != nil {
+			return nil, fmt.Errorf("could not unpack request: %w", err)
+		}
+		return request, nil
+
+	case MessagePrePrepare:
+		var preprepare PrePrepare
+		err = json.Unmarshal(msg.Data, &preprepare)
+		if err != nil {
+			return nil, fmt.Errorf("could not unpack pre-prepare message: %w", err)
+		}
+		return preprepare, nil
+
+	case MessagePrepare:
+		var prepare Prepare
+		err = json.Unmarshal(msg.Data, &prepare)
+		if err != nil {
+			return nil, fmt.Errorf("could not unpack prepare message: %w", err)
+		}
+		return prepare, nil
+
+	case MessageCommit:
+		var commit Commit
+		err = json.Unmarshal(msg.Data, &commit)
+		if err != nil {
+			return nil, fmt.Errorf("could not unpack commit message: %w", err)
+		}
+		return commit, nil
+	}
+
+	return nil, fmt.Errorf("unexpected message type (type: %v)", msg.Type)
+}

--- a/consensus/pbft/message.go
+++ b/consensus/pbft/message.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/blocklessnetworking/b7s/models/execute"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
@@ -63,15 +64,27 @@ type PrePrepare struct {
 
 func (p PrePrepare) MarshalJSON() ([]byte, error) {
 
-	// Define an alias without the JSON marshaller.
-	type alias PrePrepare
+	// Define aliases without the JSON marshaller.
+	type arequest Request
+	type alias struct {
+		View           uint     `json:"view"`
+		SequenceNumber uint     `json:"sequence_number"`
+		Digest         string   `json:"digest"`
+		Request        arequest `json:"request"`
+	}
+
 	return json.Marshal(
 		struct {
 			Type MessageType `json:"type"`
 			Data alias       `json:"data"`
 		}{
 			Type: MessagePrePrepare,
-			Data: alias(p),
+			Data: alias{
+				View:           p.View,
+				SequenceNumber: p.SequenceNumber,
+				Digest:         p.Digest,
+				Request:        arequest(p.Request),
+			},
 		})
 }
 

--- a/consensus/pbft/message.go
+++ b/consensus/pbft/message.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 type MessageType uint
@@ -31,10 +32,10 @@ func (m MessageType) String() string {
 }
 
 type Request struct {
-	ID        string    `json:"id"`
-	Timestamp time.Time `json:"timestamp"`
-	// TODO: Comes from the client, add relevant stuff here. Rethink this model.
-	Execute execute.Request `json:"execute"`
+	ID        string          `json:"id"`
+	Timestamp time.Time       `json:"timestamp"`
+	Origin    peer.ID         `json:"origin"`
+	Execute   execute.Request `json:"execute"`
 }
 
 func (r Request) MarshalJSON() ([]byte, error) {

--- a/consensus/pbft/message.go
+++ b/consensus/pbft/message.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/blocklessnetworking/b7s/models/execute"
 )
 
@@ -33,9 +31,24 @@ func (m MessageType) String() string {
 }
 
 type Request struct {
+	ID        string    `json:"id"`
 	Timestamp time.Time `json:"timestamp"`
 	// TODO: Comes from the client, add relevant stuff here. Rethink this model.
 	Execute execute.Request `json:"execute"`
+}
+
+func (r Request) MarshalJSON() ([]byte, error) {
+
+	// Define an alias without the JSON marshaller.
+	type alias Request
+	return json.Marshal(
+		struct {
+			Type MessageType `json:"type"`
+			Data alias       `json:"data"`
+		}{
+			Type: MessageRequest,
+			Data: alias(r),
+		})
 }
 
 // TODO: In fabric code, all messages have a `replicaID` field.
@@ -45,7 +58,6 @@ type PrePrepare struct {
 	SequenceNumber uint    `json:"sequence_number"`
 	Digest         string  `json:"digest"`
 	Request        Request `json:"request"`
-	ReplicaID      peer.ID `json:"replica"`
 }
 
 func (p PrePrepare) MarshalJSON() ([]byte, error) {
@@ -63,10 +75,9 @@ func (p PrePrepare) MarshalJSON() ([]byte, error) {
 }
 
 type Prepare struct {
-	View           uint    `json:"view"`
-	SequenceNumber uint    `json:"sequence_number"`
-	Digest         string  `json:"digest"`
-	ReplicaID      peer.ID `json:"replica"`
+	View           uint   `json:"view"`
+	SequenceNumber uint   `json:"sequence_number"`
+	Digest         string `json:"digest"`
 }
 
 func (p Prepare) MarshalJSON() ([]byte, error) {
@@ -82,10 +93,9 @@ func (p Prepare) MarshalJSON() ([]byte, error) {
 }
 
 type Commit struct {
-	View           uint    `json:"view"`
-	SequenceNumber uint    `json:"sequence_number"`
-	Digest         string  `json:"digest"`
-	ReplicaID      peer.ID `json:"replica"`
+	View           uint   `json:"view"`
+	SequenceNumber uint   `json:"sequence_number"`
+	Digest         string `json:"digest"`
 }
 
 func (c Commit) MarshalJSON() ([]byte, error) {

--- a/consensus/pbft/message_test.go
+++ b/consensus/pbft/message_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/blocklessnetworking/b7s/testing/mocks"
 )
 
 func TestMessage_Encode(t *testing.T) {
@@ -17,7 +15,6 @@ func TestMessage_Encode(t *testing.T) {
 			View:           1,
 			SequenceNumber: 2,
 			Digest:         "123456789",
-			ReplicaID:      mocks.GenericPeerID,
 		}
 
 		encoded, err := json.Marshal(orig)
@@ -43,7 +40,6 @@ func TestMessage_Encode(t *testing.T) {
 			View:           14,
 			SequenceNumber: 45,
 			Digest:         "abc123def",
-			ReplicaID:      mocks.GenericPeerID,
 		}
 
 		encoded, err := json.Marshal(orig)
@@ -69,7 +65,6 @@ func TestMessage_Encode(t *testing.T) {
 			View:           23,
 			SequenceNumber: 51,
 			Digest:         "987xyz",
-			ReplicaID:      mocks.GenericPeerID,
 		}
 
 		encoded, err := json.Marshal(orig)
@@ -100,7 +95,6 @@ func TestMessage_Decode(t *testing.T) {
 			View:           1,
 			SequenceNumber: 2,
 			Digest:         "123456789",
-			ReplicaID:      mocks.GenericPeerID,
 		}
 
 		encoded, err := json.Marshal(orig)
@@ -122,7 +116,6 @@ func TestMessage_Decode(t *testing.T) {
 			View:           14,
 			SequenceNumber: 45,
 			Digest:         "abc123def",
-			ReplicaID:      mocks.GenericPeerID,
 		}
 
 		encoded, err := json.Marshal(orig)
@@ -144,7 +137,6 @@ func TestMessage_Decode(t *testing.T) {
 			View:           23,
 			SequenceNumber: 51,
 			Digest:         "987xyz",
-			ReplicaID:      mocks.GenericPeerID,
 		}
 
 		encoded, err := json.Marshal(orig)

--- a/consensus/pbft/message_test.go
+++ b/consensus/pbft/message_test.go
@@ -1,0 +1,164 @@
+package pbft
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+)
+
+func TestMessage_Encode(t *testing.T) {
+
+	t.Run("pre-prepare", func(t *testing.T) {
+
+		orig := PrePrepare{
+			View:           1,
+			SequenceNumber: 2,
+			Digest:         "123456789",
+			ReplicaID:      mocks.GenericPeerID,
+		}
+
+		encoded, err := json.Marshal(orig)
+		require.NoError(t, err)
+
+		var unpacked messageRecord
+		err = json.Unmarshal(encoded, &unpacked)
+		require.NoError(t, err)
+
+		// Verify that the message type was correctly set.
+		require.Equal(t, MessagePrePrepare, unpacked.Type)
+
+		// Verofy that the original data is correctly encoded.
+		var msg PrePrepare
+		err = json.Unmarshal(unpacked.Data, &msg)
+		require.NoError(t, err)
+
+		require.Equal(t, orig, msg)
+	})
+	t.Run("prepare", func(t *testing.T) {
+
+		orig := Prepare{
+			View:           14,
+			SequenceNumber: 45,
+			Digest:         "abc123def",
+			ReplicaID:      mocks.GenericPeerID,
+		}
+
+		encoded, err := json.Marshal(orig)
+		require.NoError(t, err)
+
+		var unpacked messageRecord
+		err = json.Unmarshal(encoded, &unpacked)
+		require.NoError(t, err)
+
+		// Verify that the message type was correctly set.
+		require.Equal(t, MessagePrepare, unpacked.Type)
+
+		// Verofy that the original data is correctly encoded.
+		var msg Prepare
+		err = json.Unmarshal(unpacked.Data, &msg)
+		require.NoError(t, err)
+
+		require.Equal(t, orig, msg)
+	})
+	t.Run("commit", func(t *testing.T) {
+
+		orig := Commit{
+			View:           23,
+			SequenceNumber: 51,
+			Digest:         "987xyz",
+			ReplicaID:      mocks.GenericPeerID,
+		}
+
+		encoded, err := json.Marshal(orig)
+		require.NoError(t, err)
+
+		var unpacked messageRecord
+		err = json.Unmarshal(encoded, &unpacked)
+		require.NoError(t, err)
+
+		// Verify that the message type was correctly set.
+		require.Equal(t, MessageCommit, unpacked.Type)
+
+		// Verofy that the original data is correctly encoded.
+		var msg Commit
+		err = json.Unmarshal(unpacked.Data, &msg)
+		require.NoError(t, err)
+
+		require.Equal(t, orig, msg)
+	})
+	// TODO (pbft): Add request handling
+}
+
+func TestMessage_Decode(t *testing.T) {
+
+	t.Run("pre-prepare", func(t *testing.T) {
+
+		orig := PrePrepare{
+			View:           1,
+			SequenceNumber: 2,
+			Digest:         "123456789",
+			ReplicaID:      mocks.GenericPeerID,
+		}
+
+		encoded, err := json.Marshal(orig)
+		require.NoError(t, err)
+
+		unpacked, err := unpackMessage(encoded)
+		require.NoError(t, err)
+
+		// Verify that the message type was correctly identified.
+		prePrepare, ok := unpacked.(PrePrepare)
+		require.True(t, ok)
+
+		// Verify that the data is correctly unpacked.
+		require.Equal(t, orig, prePrepare)
+	})
+	t.Run("prepare", func(t *testing.T) {
+
+		orig := Prepare{
+			View:           14,
+			SequenceNumber: 45,
+			Digest:         "abc123def",
+			ReplicaID:      mocks.GenericPeerID,
+		}
+
+		encoded, err := json.Marshal(orig)
+		require.NoError(t, err)
+
+		unpacked, err := unpackMessage(encoded)
+		require.NoError(t, err)
+
+		// Verify that the message type was correctly identified.
+		prepare, ok := unpacked.(Prepare)
+		require.True(t, ok)
+
+		// Verify that the data is correctly unpacked.
+		require.Equal(t, orig, prepare)
+	})
+	t.Run("commit", func(t *testing.T) {
+
+		orig := Commit{
+			View:           23,
+			SequenceNumber: 51,
+			Digest:         "987xyz",
+			ReplicaID:      mocks.GenericPeerID,
+		}
+
+		encoded, err := json.Marshal(orig)
+		require.NoError(t, err)
+
+		unpacked, err := unpackMessage(encoded)
+		require.NoError(t, err)
+
+		// Verify that the message type was correctly identified.
+		commit, ok := unpacked.(Commit)
+		require.True(t, ok)
+
+		// Verify that the data is correctly unpacked.
+		require.Equal(t, orig, commit)
+	})
+	// TODO (pbft): Add request handling
+}

--- a/consensus/pbft/messaging.go
+++ b/consensus/pbft/messaging.go
@@ -20,7 +20,7 @@ func (r *Replica) send(to peer.ID, msg interface{}) error {
 	}
 
 	// Send message.
-	err = r.host.SendMessage(context.Background(), to, payload)
+	err = r.host.SendMessageOnProtocol(context.Background(), to, payload, Protocol)
 	if err != nil {
 		return fmt.Errorf("could not send message: %w", err)
 	}
@@ -42,7 +42,13 @@ func (r *Replica) broadcast(msg interface{}) error {
 	}
 
 	for _, peer := range r.peers {
-		err = r.host.SendMessage(context.Background(), peer, payload)
+
+		// Skip self.
+		if peer == r.id {
+			continue
+		}
+
+		err = r.host.SendMessageOnProtocol(context.Background(), peer, payload, Protocol)
 		if err != nil {
 			return fmt.Errorf("could not send message: %w", err)
 		}

--- a/consensus/pbft/messaging.go
+++ b/consensus/pbft/messaging.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 )
-
-// TODO (pbft): Consider creating an abstraction like a "network stack" that will be cognizant of the peers in a cluster.
-// TODO (pbft): context.Background() used at the moment, fix.
 
 func (r *Replica) send(to peer.ID, msg interface{}, protocol protocol.ID) error {
 
@@ -20,8 +20,12 @@ func (r *Replica) send(to peer.ID, msg interface{}, protocol protocol.ID) error 
 		return fmt.Errorf("could not encode record: %w", err)
 	}
 
+	// We don't want to wait indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), NetworkTimeout)
+	defer cancel()
+
 	// Send message.
-	err = r.host.SendMessageOnProtocol(context.Background(), to, payload, protocol)
+	err = r.host.SendMessageOnProtocol(ctx, to, payload, protocol)
 	if err != nil {
 		return fmt.Errorf("could not send message: %w", err)
 	}
@@ -32,27 +36,58 @@ func (r *Replica) send(to peer.ID, msg interface{}, protocol protocol.ID) error 
 // broadcast sends message to all peers in the replica set.
 func (r *Replica) broadcast(msg interface{}) error {
 
-	// TODO (pbft): Harden this. Consider what to do when some sends fail. Say we failed or retry?
-	//	It's a valid scenario that some peers may be offline, so we should probably continue
-	//	despite errors, at least to a point.
-
 	// Serialize the message.
 	payload, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("could not encode record: %w", err)
 	}
 
-	for _, peer := range r.peers {
+	ctx, cancel := context.WithTimeout(context.Background(), NetworkTimeout)
+	defer cancel()
 
+	var (
+		wg       sync.WaitGroup
+		multierr *multierror.Error
+		lock     sync.Mutex
+	)
+
+	for _, target := range r.peers {
 		// Skip self.
-		if peer == r.id {
+		if target == r.id {
 			continue
 		}
 
-		err = r.host.SendMessageOnProtocol(context.Background(), peer, payload, Protocol)
-		if err != nil {
-			return fmt.Errorf("could not send message: %w", err)
-		}
+		wg.Add(1)
+
+		// Send concurrently to everyone.
+		go func(peer peer.ID) {
+			defer wg.Done()
+
+			// NOTE: We could potentially retry sending to nodes if we fail once. On the other hand, somewhat unlikely they're
+			// back online split second later.
+
+			err := r.host.SendMessageOnProtocol(ctx, peer, payload, Protocol)
+			if err != nil {
+
+				lock.Lock()
+				defer lock.Unlock()
+
+				multierr = multierror.Append(multierr, err)
+			}
+		}(target)
+	}
+
+	wg.Wait()
+
+	// Warn if we had more send errors than we bargained for.
+	errCount := uint(multierr.Len())
+	if errCount > r.f {
+		r.log.Warn().Uint("f", r.f).Uint("errors", errCount).Msg("broadcast error count higher than pBFT f value")
+	}
+
+	sendErr := multierr.ErrorOrNil()
+	if sendErr != nil {
+		return fmt.Errorf("could not broadcast message: %w", sendErr)
 	}
 
 	return nil

--- a/consensus/pbft/messaging.go
+++ b/consensus/pbft/messaging.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 )
 
 // TODO (pbft): Consider creating an abstraction like a "network stack" that will be cognizant of the peers in a cluster.
 // TODO (pbft): context.Background() used at the moment, fix.
 
-func (r *Replica) send(to peer.ID, msg interface{}) error {
+func (r *Replica) send(to peer.ID, msg interface{}, protocol protocol.ID) error {
 
 	// Serialize the message.
 	payload, err := json.Marshal(msg)
@@ -20,7 +21,7 @@ func (r *Replica) send(to peer.ID, msg interface{}) error {
 	}
 
 	// Send message.
-	err = r.host.SendMessageOnProtocol(context.Background(), to, payload, Protocol)
+	err = r.host.SendMessageOnProtocol(context.Background(), to, payload, protocol)
 	if err != nil {
 		return fmt.Errorf("could not send message: %w", err)
 	}

--- a/consensus/pbft/messaging.go
+++ b/consensus/pbft/messaging.go
@@ -1,0 +1,52 @@
+package pbft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// TODO (pbft): Consider creating an abstraction like a "network stack" that will be cognizant of the peers in a cluster.
+// TODO (pbft): context.Background() used at the moment, fix.
+
+func (r *Replica) send(to peer.ID, msg interface{}) error {
+
+	// Serialize the message.
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("could not encode record: %w", err)
+	}
+
+	// Send message.
+	err = r.host.SendMessage(context.Background(), to, payload)
+	if err != nil {
+		return fmt.Errorf("could not send message: %w", err)
+	}
+
+	return nil
+}
+
+// broadcast sends message to all peers in the replica set.
+func (r *Replica) broadcast(msg interface{}) error {
+
+	// TODO (pbft): Harden this. Consider what to do when some sends fail. Say we failed or retry?
+	//	It's a valid scenario that some peers may be offline, so we should probably continue
+	//	despite errors, at least to a point.
+
+	// Serialize the message.
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("could not encode record: %w", err)
+	}
+
+	for _, peer := range r.peers {
+		err = r.host.SendMessage(context.Background(), peer, payload)
+		if err != nil {
+			return fmt.Errorf("could not send message: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/consensus/pbft/params.go
+++ b/consensus/pbft/params.go
@@ -1,6 +1,8 @@
 package pbft
 
 import (
+	"time"
+
 	"github.com/libp2p/go-libp2p/core/protocol"
 )
 
@@ -8,6 +10,9 @@ const (
 	// Protocol to use for PBFT related communication.
 	Protocol protocol.ID = "/b7s/consensus/pbft/1.0.0"
 
-	// PBFT offers no resiliency regarding Byzantine nodes with less than four nodes.
+	// PBFT offers no resiliency towards Byzantine nodes with less than four nodes.
 	MinimumReplicaCount = 4
+
+	// How long do the send/broadcast operation have until we consider it failed.
+	NetworkTimeout = 5 * time.Second
 )

--- a/consensus/pbft/params.go
+++ b/consensus/pbft/params.go
@@ -1,0 +1,13 @@
+package pbft
+
+import (
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+const (
+	// Protocol to use for PBFT related communication.
+	Protocol protocol.ID = "/b7s/consensus/pbft/1.0.0"
+
+	// PBFT offers no resiliency regarding Byzantine nodes with less than four nodes.
+	MinimumReplicaCount = 4
+)

--- a/consensus/pbft/pbft.go
+++ b/consensus/pbft/pbft.go
@@ -1,0 +1,159 @@
+package pbft
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/rs/zerolog"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetworking/b7s/host"
+)
+
+// TODO (pbft): View change.
+
+// Replica is a single PBFT node. Both Primary and Backup nodes are all replicas.
+type Replica struct {
+	pbftCore
+	log  zerolog.Logger
+	host *host.Host
+
+	id    peer.ID
+	key   crypto.PrivKey
+	peers []peer.ID
+
+	// TODO (pbft): locking for these.
+
+	// Keep track of seen requests. Map request to the digest.
+	requests map[string]Request
+	// Keep track of requests queued for execution. Could also be tracked via a single map.
+	pending map[string]Request
+
+	// Keep track of seen pre-prepare messages.
+	preprepares map[messageID]PrePrepare
+	// Keep track of seen prepare messages.
+	prepares map[messageID]*prepareReceipts
+	// Keep track of seen commit messages.
+	commits map[messageID]*commitReceipts
+}
+
+// NewReplica creates a new PBFT replica.
+func NewReplica(log zerolog.Logger, host *host.Host, peers []peer.ID, key crypto.PrivKey) (*Replica, error) {
+
+	total := uint(len(peers))
+
+	if total < MinimumReplicaCount {
+		return nil, fmt.Errorf("too small cluster for a valid PBFT (have: %v, minimum: %v)", total, MinimumReplicaCount)
+	}
+
+	replica := Replica{
+		pbftCore: newPbftCore(total),
+		log:      log.With().Str("component", "pbft").Logger(),
+		host:     host,
+
+		id:    host.ID(),
+		key:   key,
+		peers: peers,
+
+		requests:    make(map[string]Request),
+		pending:     make(map[string]Request),
+		preprepares: make(map[messageID]PrePrepare),
+		prepares:    make(map[messageID]*prepareReceipts),
+		commits:     make(map[messageID]*commitReceipts),
+	}
+
+	log.Info().Strs("replicas", peerIDList(peers)).Uint("total", total).Msg("created PBFT replica")
+
+	// Set the message handler.
+	// TODO (pbft): Split the protocols - requests should come in on the regular `b7s` protocol, while the replica communication should be on the other, `pbft cluster consensus` protocol.
+	replica.setMessageHandler()
+
+	return &replica, nil
+}
+
+func (r *Replica) setMessageHandler() {
+
+	// We want to only accept messages from replicas in our cluster.
+	// Create a map so we can perform a faster lookup.
+	pm := make(map[peer.ID]struct{})
+	for _, peer := range r.peers {
+		pm[peer] = struct{}{}
+	}
+
+	r.host.Host.SetStreamHandler(Protocol, func(stream network.Stream) {
+		defer stream.Close()
+
+		from := stream.Conn().RemotePeer()
+
+		// TODO (pbft): This makes sense but more locally - we have to allow requests to come in lul.
+		/*
+			_, known := pm[from]
+			if !known {
+				r.log.Info().Str("peer", from.String()).Msg("received message from a peer not in our cluster, discarding")
+				return
+			}
+		*/
+
+		buf := bufio.NewReader(stream)
+		msg, err := buf.ReadBytes('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			stream.Reset()
+			r.log.Error().Err(err).Msg("error receiving direct message")
+			return
+		}
+
+		r.log.Debug().Str("peer", from.String()).Msg("received message")
+
+		err = r.processMessage(from, msg)
+		if err != nil {
+			r.log.Error().Err(err).Str("peer", from.String()).Msg("message processing failed")
+		}
+	})
+}
+
+func (r *Replica) processMessage(from peer.ID, payload []byte) error {
+
+	msg, err := unpackMessage(payload)
+	if err != nil {
+		return fmt.Errorf("could not unpack message: %w", err)
+	}
+
+	switch m := msg.(type) {
+
+	case Request:
+		return r.processRequest(from, m)
+
+	case PrePrepare:
+		return r.processPrePrepare(from, m)
+
+	case Prepare:
+		return r.processPrepare(from, m)
+
+	case Commit:
+		return r.processCommit(from, m)
+	}
+
+	return fmt.Errorf("unexpected message type (from: %s): %T", from, msg)
+}
+
+func (r *Replica) primaryReplicaID() peer.ID {
+	return r.peers[r.currentPrimary()]
+}
+
+func (r *Replica) isPrimary() bool {
+	return r.id == r.primaryReplicaID()
+}
+
+// helper function to to convert a slice of multiaddrs to strings.
+func peerIDList(ids []peer.ID) []string {
+	peerIDs := make([]string, 0, len(ids))
+	for _, rp := range ids {
+		peerIDs = append(peerIDs, rp.String())
+	}
+	return peerIDs
+}

--- a/consensus/pbft/pbft.go
+++ b/consensus/pbft/pbft.go
@@ -165,6 +165,9 @@ func (r *Replica) setGeneralMessageHandler() {
 			return
 		}
 
+		r.sl.Lock()
+		defer r.sl.Unlock()
+
 		err = r.processRequest(from, req)
 		if err != nil {
 			r.log.Error().Err(err).Str("request", req.ID).Str("origin", req.Origin.String()).Msg("could not process request")

--- a/consensus/pbft/pbft.go
+++ b/consensus/pbft/pbft.go
@@ -57,6 +57,7 @@ func NewReplica(log zerolog.Logger, host *host.Host, executor Executor, peers []
 		pbftCore: newPbftCore(total),
 		log:      log.With().Str("component", "pbft").Logger(),
 		host:     host,
+		executor: executor,
 
 		id:    host.ID(),
 		key:   key,

--- a/consensus/pbft/prepare.go
+++ b/consensus/pbft/prepare.go
@@ -65,6 +65,10 @@ func (r *Replica) processPrepare(replica peer.ID, prepare Prepare) error {
 		return nil
 	}
 
+	if prepare.View != r.view {
+		return fmt.Errorf("prepare has an invalid view value (received: %v, current: %v)", prepare.View, r.view)
+	}
+
 	r.recordPrepareReceipt(replica, prepare)
 
 	log.Info().Msg("processed prepare message")

--- a/consensus/pbft/prepare.go
+++ b/consensus/pbft/prepare.go
@@ -1,0 +1,73 @@
+package pbft
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Send a prepare message. Naturally this is only sent by the non-primary replicas,
+// as a response to a pre-prepare message.
+func (r *Replica) sendPrepare(preprepare PrePrepare) error {
+
+	msg := Prepare{
+		View:           preprepare.View,
+		SequenceNumber: preprepare.SequenceNumber,
+		Digest:         preprepare.Digest,
+	}
+
+	log := r.log.With().Str("digest", msg.Digest).Uint("view", msg.View).Uint("sequence_number", msg.SequenceNumber).Logger()
+
+	log.Info().Msg("broadcasting prepare message")
+
+	err := r.broadcast(msg)
+	if err != nil {
+		return fmt.Errorf("could not broadcast prepare message: %w", err)
+	}
+
+	log.Info().Msg("prepare message successfully broadcast")
+
+	// Record this prepare message.
+	r.recordPrepareReceipt(r.id, msg)
+
+	return nil
+}
+
+func (r *Replica) recordPrepareReceipt(replica peer.ID, prepare Prepare) {
+
+	msgID := getMessageID(prepare.View, prepare.SequenceNumber)
+	prepares, ok := r.prepares[msgID]
+	if !ok {
+		r.prepares[msgID] = newPrepareReceipts()
+		prepares = r.prepares[msgID]
+	}
+
+	prepares.Lock()
+	defer prepares.Unlock()
+
+	_, exists := prepares.m[replica]
+	if exists {
+		r.log.Warn().Uint("view", prepare.View).Uint("sequence_number", prepare.SequenceNumber).Str("digest", prepare.Digest).Str("replica", replica.String()).Msg("ignoring duplicate prepare message")
+		return
+	}
+
+	prepares.m[replica] = prepare
+}
+
+func (r *Replica) processPrepare(replica peer.ID, prepare Prepare) error {
+
+	log := r.log.With().Str("replica", replica.String()).Uint("view", prepare.View).Uint("sequence_no", prepare.SequenceNumber).Str("digest", prepare.Digest).Logger()
+
+	log.Info().Msg("received prepare message")
+
+	if replica == r.primaryReplicaID() {
+		log.Warn().Msg("received prepare message from primary, ignoring")
+		return nil
+	}
+
+	r.recordPrepareReceipt(replica, prepare)
+
+	log.Info().Msg("processed prepare message")
+
+	return r.maybeSendCommit(prepare.View, prepare.SequenceNumber, prepare.Digest)
+}

--- a/consensus/pbft/preprepare.go
+++ b/consensus/pbft/preprepare.go
@@ -63,6 +63,10 @@ func (r *Replica) processPrePrepare(replica peer.ID, msg PrePrepare) error {
 		return nil
 	}
 
+	if msg.View != r.view {
+		return fmt.Errorf("pre-prepare has an invalid view value (received: %v, current: %v)", msg.View, r.view)
+	}
+
 	id := getMessageID(msg.View, msg.SequenceNumber)
 
 	// TODO (pbft): in reality more involved, for now we'll stop if there's something existing already.

--- a/consensus/pbft/preprepare.go
+++ b/consensus/pbft/preprepare.go
@@ -1,0 +1,107 @@
+package pbft
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func (r *Replica) sendPrePrepare(req Request) error {
+
+	// Only primary replica can send pre-prepares.
+	if !r.isPrimary() {
+		return nil
+	}
+
+	// TODO: Check - is there a reason we just don't use 0 too?
+	seqNo := r.sequence + 1
+	r.sequence++
+
+	msg := PrePrepare{
+		View:           r.view,
+		SequenceNumber: seqNo,
+		Request:        req,
+		Digest:         getDigest(req),
+	}
+
+	log := r.log.With().Uint("view", msg.View).Uint("sequence_number", msg.SequenceNumber).Str("digest", msg.Digest).Logger()
+
+	// TODO (pbft): Check if we had this or other pre-prepares for this request.
+	if r.conflictingPrePrepare(msg) {
+		return fmt.Errorf("dropping pre-prepare as we have a conflicting one")
+	}
+
+	log.Info().Msg("broadcasting pre-prepare message")
+
+	err := r.broadcast(msg)
+	if err != nil {
+		return fmt.Errorf("could not broadcast pre-prepare message: %w", err)
+	}
+
+	log.Info().Msg("pre-prepare message successfully broadcast")
+
+	// Take a note of this pre-prepare. This will naturally only happen on the primary replica.
+	r.preprepares[getMessageID(msg.View, msg.SequenceNumber)] = msg
+
+	return nil
+}
+
+// Process a pre-prepare message. This should naturally only happen on non-primary replicas.
+func (r *Replica) processPrePrepare(replica peer.ID, msg PrePrepare) error {
+
+	if r.isPrimary() {
+		r.log.Warn().Msg("primary replica received a pre-prepare, dropping")
+		return nil
+	}
+
+	log := r.log.With().Str("replica", replica.String()).Uint("view", msg.View).Uint("sequence_no", msg.SequenceNumber).Str("digest", msg.Digest).Logger()
+
+	log.Info().Msg("received pre-prepare message")
+
+	if replica != r.primaryReplicaID() {
+		log.Warn().Str("primary", r.primaryReplicaID().String()).Msg("pre-prepare came from a replica that is not the primary, dropping")
+		return nil
+	}
+
+	id := getMessageID(msg.View, msg.SequenceNumber)
+
+	// TODO (pbft): in reality more involved, for now we'll stop if there's something existing already.
+	existing, ok := r.preprepares[id]
+	if ok {
+		log.Warn().Str("existing_digest", existing.Digest).Msg("pre-prepare message already exists for this view and sequence number, dropping")
+		return nil
+	}
+
+	// We don't have this pre-prepare. Save it now.
+	r.preprepares[id] = msg
+
+	// Save this request.
+	r.requests[msg.Digest] = msg.Request
+	r.pending[msg.Digest] = msg.Request
+
+	if !r.prePrepared(msg.View, msg.SequenceNumber, msg.Digest) {
+		log.Warn().Msg("request is not pre-prepared, stopping")
+		return nil
+	}
+
+	// Broadcast prepare message.
+	err := r.sendPrepare(msg)
+	if err != nil {
+		return fmt.Errorf("could not send prepare message: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Replica) conflictingPrePrepare(preprepare PrePrepare) bool {
+
+	for _, pp := range r.preprepares {
+
+		// If we have a pre-prepare with the same view and same digest but different sequence number - invalid.
+		if pp.View == preprepare.View && pp.Digest == preprepare.Digest && pp.SequenceNumber != preprepare.SequenceNumber {
+			return true
+		}
+	}
+
+	return false
+}

--- a/consensus/pbft/receipts.go
+++ b/consensus/pbft/receipts.go
@@ -1,0 +1,38 @@
+package pbft
+
+import (
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// prepareReceipts maps a peer/replica ID to the prepare message it sent.
+type prepareReceipts struct {
+	m map[peer.ID]Prepare
+	*sync.Mutex
+}
+
+func newPrepareReceipts() *prepareReceipts {
+
+	pr := prepareReceipts{
+		m:     make(map[peer.ID]Prepare),
+		Mutex: &sync.Mutex{},
+	}
+
+	return &pr
+}
+
+type commitReceipts struct {
+	m map[peer.ID]Commit
+	*sync.Mutex
+}
+
+func newCommitReceipts() *commitReceipts {
+
+	cr := commitReceipts{
+		m:     make(map[peer.ID]Commit),
+		Mutex: &sync.Mutex{},
+	}
+
+	return &cr
+}

--- a/consensus/pbft/request.go
+++ b/consensus/pbft/request.go
@@ -1,0 +1,39 @@
+package pbft
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func (r *Replica) processRequest(from peer.ID, req Request) error {
+
+	r.log.Info().Str("peer", from.String()).Str("id", req.ID).Msg("received a request")
+
+	// If we're not the primary, we'll drop the request.
+	if !r.isPrimary() {
+		r.log.Warn().Str("primary", r.primaryReplicaID().String()).Msg("we are not the primary replica, dropping the request")
+		return nil
+	}
+
+	digest := getDigest(req)
+
+	r.log.Info().Str("id", req.ID).Str("digest", digest).Msg("we are the primary, processing the request")
+
+	_, found := r.requests[digest]
+	if found {
+		return fmt.Errorf("already seen this request, dropping")
+	}
+
+	// Take a note of this request.
+	r.requests[digest] = req
+	r.pending[digest] = req
+
+	// Broadcast a pre-prepare message.
+	err := r.sendPrePrepare(req)
+	if err != nil {
+		return fmt.Errorf("could not broadcast pre-prepare message: %w", err)
+	}
+
+	return nil
+}

--- a/consensus/pbft/state.go
+++ b/consensus/pbft/state.go
@@ -1,0 +1,39 @@
+package pbft
+
+import (
+	"sync"
+)
+
+type replicaState struct {
+	// State lock. This is a global lock for all state maps (pre-prepares, prepares, commits etc).
+	// Even though access to those could be managed on a more granular level, at the moment I'm not
+	// sure it's worth it.
+	sl *sync.Mutex
+
+	// Keep track of seen requests. Map request to the digest.
+	requests map[string]Request
+	// Keep track of requests queued for execution. Could also be tracked via a single map.
+	pending map[string]Request
+
+	// Keep track of seen pre-prepare messages.
+	preprepares map[messageID]PrePrepare
+	// Keep track of seen prepare messages.
+	prepares map[messageID]*prepareReceipts
+	// Keep track of seen commit messages.
+	commits map[messageID]*commitReceipts
+}
+
+func newState() replicaState {
+
+	state := replicaState{
+		sl: &sync.Mutex{},
+
+		requests:    make(map[string]Request),
+		pending:     make(map[string]Request),
+		preprepares: make(map[messageID]PrePrepare),
+		prepares:    make(map[messageID]*prepareReceipts),
+		commits:     make(map[messageID]*commitReceipts),
+	}
+
+	return state
+}

--- a/host/send.go
+++ b/host/send.go
@@ -5,14 +5,20 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/blocklessnetworking/b7s/models/blockless"
 )
 
-// SendMessage sends a message directly to the specified peer.
+// SendMessage sends a message directly to the specified peer, on the standard blockless protocol.
 func (h *Host) SendMessage(ctx context.Context, to peer.ID, payload []byte) error {
+	return h.SendMessageOnProtocol(ctx, to, payload, blockless.ProtocolID)
+}
 
-	stream, err := h.Host.NewStream(ctx, to, blockless.ProtocolID)
+// SendMessageOnProtocol sends a message directly to the specified peer, using the specified protocol.
+func (h *Host) SendMessageOnProtocol(ctx context.Context, to peer.ID, payload []byte, protocol protocol.ID) error {
+
+	stream, err := h.Host.NewStream(ctx, to, protocol)
 	if err != nil {
 		return fmt.Errorf("could not create stream: %w", err)
 	}


### PR DESCRIPTION
Description: TBD

This PR adds the basic skeleton for PBFT consensus. It can be used to bootstrap PBFT replicas that will go through the stages of the PBFT consensus - the `pre-prepare`, `prepare` and `commit` stages, as well as executing the request and sending the response.

View change implementation will be part of a separate PR for easier review.