### PR TITLE
Add support for DNS name for dialback address

### DIFF
--- a/cmd/node/address.go
+++ b/cmd/node/address.go
@@ -4,27 +4,7 @@ import (
 	"fmt"
 
 	"github.com/multiformats/go-multiaddr"
-
-	"github.com/blocklessnetworking/b7s/models/blockless"
 )
-
-// getPeerAddresses returns the list of the multiaddreses for the peer list.
-func getPeerAddresses(peers []blockless.Peer) ([]multiaddr.Multiaddr, error) {
-
-	var addrs []multiaddr.Multiaddr
-
-	for _, peer := range peers {
-
-		addr, err := multiaddr.NewMultiaddr(peer.MultiAddr)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse multiaddress (addr: %s): %w", peer.MultiAddr, err)
-		}
-
-		addrs = append(addrs, addr)
-	}
-
-	return addrs, nil
-}
 
 // parse list of strings with multiaddresses
 func getBootNodeAddresses(addrs []string) ([]multiaddr.Multiaddr, error) {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -87,11 +87,6 @@ func run() int {
 		log.Error().Err(err).Msg("could not get list of dial-back peers")
 		return failure
 	}
-	peerAddrs, err := getPeerAddresses(peers)
-	if err != nil {
-		log.Error().Err(err).Msg("could not get peer addresses")
-		return failure
-	}
 
 	// Get the list of boot nodes addresses.
 	bootNodeAddrs, err := getBootNodeAddresses(cfg.BootNodes)
@@ -104,7 +99,7 @@ func run() int {
 	host, err := host.New(log, cfg.Host.Address, cfg.Host.Port,
 		host.WithPrivateKey(cfg.Host.PrivateKey),
 		host.WithBootNodes(bootNodeAddrs),
-		host.WithDialBackPeers(peerAddrs),
+		host.WithDialBackPeers(peers),
 		host.WithDialBackAddress(cfg.Host.DialBackAddress),
 		host.WithDialBackPort(cfg.Host.DialBackPort),
 		host.WithDialBackWebsocketPort(cfg.Host.DialBackWebsocketPort),
@@ -120,7 +115,7 @@ func run() int {
 		Str("id", host.ID().String()).
 		Strs("addresses", host.Addresses()).
 		Int("boot_nodes", len(bootNodeAddrs)).
-		Int("dial_back_peers", len(peerAddrs)).
+		Int("dial_back_peers", len(peers)).
 		Msg("created host")
 
 	// Set node options.

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 
 require (
 	github.com/armon/go-metrics v0.4.1 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=

--- a/host/config.go
+++ b/host/config.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/multiformats/go-multiaddr"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
 )
 
 // defaultConfig used to create Host.
@@ -21,7 +23,7 @@ type Config struct {
 
 	ConnectionThreshold uint
 	BootNodes           []multiaddr.Multiaddr
-	DialBackPeers       []multiaddr.Multiaddr
+	DialBackPeers       []blockless.Peer
 	DialBackPeersLimit  uint
 	DiscoveryInterval   time.Duration
 
@@ -55,7 +57,7 @@ func WithBootNodes(nodes []multiaddr.Multiaddr) func(*Config) {
 }
 
 // WithDialBackPeers specifies dial-back peers that the host initially tries to connect to.
-func WithDialBackPeers(peers []multiaddr.Multiaddr) func(*Config) {
+func WithDialBackPeers(peers []blockless.Peer) func(*Config) {
 	return func(cfg *Config) {
 		cfg.DialBackPeers = peers
 	}

--- a/host/dht.go
+++ b/host/dht.go
@@ -3,7 +3,6 @@ package host
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -11,6 +10,8 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
 	"github.com/libp2p/go-libp2p/p2p/discovery/util"
+
+	"github.com/blocklessnetworking/b7s/models/blockless"
 )
 
 func (h *Host) DiscoverPeers(ctx context.Context, topic string) error {
@@ -86,17 +87,34 @@ func (h *Host) initDHT(ctx context.Context) (*dht.IpfsDHT, error) {
 		return nil, fmt.Errorf("could not bootstrap the DHT: %w", err)
 	}
 
-	bootNodes := h.cfg.BootNodes
-	peers := h.cfg.DialBackPeers
+	// Nodes we will try to connect to on start.
+	var bootNodes []blockless.Peer
+
+	// Add explicitly specified nodes first.
+	for _, addr := range h.cfg.BootNodes {
+		addr := addr
+
+		addrInfo, err := peer.AddrInfoFromP2pAddr(addr)
+		if err != nil {
+			h.log.Warn().Err(err).Str("address", addr.String()).Msg("could not get addrinfo for boot node - skipping")
+			continue
+		}
+
+		node := blockless.Peer{
+			ID:       addrInfo.ID,
+			AddrInfo: *addrInfo,
+		}
+
+		bootNodes = append(bootNodes, node)
+	}
 
 	// Add the dial-back peers to the list of bootstrap nodes if they do not already exist.
-	// TODO: Limit to workers.
 
 	// We may want to limit the number of dial back peers we use.
 	added := uint(0)
 	addLimit := h.cfg.DialBackPeersLimit
 
-	for _, peer := range peers {
+	for _, peer := range h.cfg.DialBackPeers {
 		peer := peer
 
 		// If the limit of dial-back peers is set and we've reached it - stop now.
@@ -105,55 +123,36 @@ func (h *Host) initDHT(ctx context.Context) (*dht.IpfsDHT, error) {
 			break
 		}
 
-		addr := peer.String()
-		addr = strings.Replace(addr, "127.0.0.1", "0.0.0.0", 1)
+		h.log.Debug().Str("peer", peer.ID.String()).Interface("addr_info", peer.AddrInfo).Msg("adding dial-back peer")
 
-		// Check if the peer is already among the boot nodes.
-		exists := false
-		for _, bootNode := range bootNodes {
-			if bootNode.String() == addr {
-				exists = true
-				break
-			}
-		}
-
-		// If the peer is not among the boot nodes - add it now.
-		if !exists {
-			bootNodes = append(bootNodes, peer)
-			added++
-		}
+		bootNodes = append(bootNodes, peer)
+		added++
 	}
 
 	// Connect to the bootstrap nodes.
 	var wg sync.WaitGroup
 	for _, bootNode := range bootNodes {
+		bootNode := bootNode
 
-		addrInfo, err := peer.AddrInfoFromP2pAddr(bootNode)
-		if err != nil {
-			h.log.Warn().
-				Err(err).
-				Str("address", bootNode.String()).
-				Msg("could not get addrinfo for boot node - skipping")
+		// Skip peers we're already connected to (perhaps a dial-back peer was also a boot node).
+		connections := h.Network().ConnsToPeer(bootNode.ID)
+		if len(connections) > 0 {
 			continue
 		}
 
 		wg.Add(1)
-
-		go func() {
+		go func(peer blockless.Peer) {
 			defer wg.Done()
 
-			peerAddr := addrInfo
+			peerAddr := peer.AddrInfo
 
-			err := h.Host.Connect(ctx, *peerAddr)
+			err := h.Host.Connect(ctx, peerAddr)
 			if err != nil {
 				if err.Error() != errNoGoodAddresses {
-					h.log.Error().
-						Err(err).
-						Str("addrinfo", peerAddr.String()).
-						Msg("could not connect to bootstrap node")
+					h.log.Error().Err(err).Str("peer", peerAddr.ID.String()).Interface("addr_info", peerAddr).Msg("could not connect to bootstrap node")
 				}
 			}
-		}()
+		}(bootNode)
 	}
 
 	// Wait until we know the outcome of all connection attempts.

--- a/host/dht.go
+++ b/host/dht.go
@@ -124,8 +124,6 @@ func (h *Host) initDHT(ctx context.Context) (*dht.IpfsDHT, error) {
 			break
 		}
 
-		h.log.Debug().Str("peer", peer.ID.String()).Interface("addr_info", peer.AddrInfo).Msg("adding dial-back peer")
-
 		// If we don't have any addresses, add the multiaddress we (hopefully) do have - last one we received a connection from.
 		if len(peer.AddrInfo.Addrs) == 0 {
 
@@ -135,8 +133,12 @@ func (h *Host) initDHT(ctx context.Context) (*dht.IpfsDHT, error) {
 				break
 			}
 
+			h.log.Debug().Str("peer", peer.ID.String()).Msg("using last known multiaddress for dial-back peer")
+
 			peer.AddrInfo.Addrs = []multiaddr.Multiaddr{ma}
 		}
+
+		h.log.Debug().Str("peer", peer.ID.String()).Interface("addr_info", peer.AddrInfo).Msg("adding dial-back peer")
 
 		bootNodes = append(bootNodes, peer)
 		added++

--- a/host/host_internal_test.go
+++ b/host/host_internal_test.go
@@ -1,0 +1,88 @@
+package host
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetermineAddressProtocol(t *testing.T) {
+
+	tests := []struct {
+		address   string
+		shouldErr bool
+		protocol  string
+	}{
+		{
+			address:   "127.0.0.1",
+			shouldErr: false,
+			protocol:  "ip4",
+		},
+		{
+			address:   "192.168.0.1",
+			shouldErr: false,
+			protocol:  "ip4",
+		},
+		{
+			address:   "::FFFF:C0A8:1",
+			shouldErr: false,
+			protocol:  "ip6",
+		},
+		{
+			address:   "0000:0000:0000:0000:0000:FFFF:C0A8:1",
+			shouldErr: false,
+			protocol:  "ip6",
+		},
+		{
+			address:   "example.com",
+			shouldErr: false,
+			protocol:  "dns",
+		},
+		{
+			address:   "foo1.bar2.com.gah.zip",
+			shouldErr: false,
+			protocol:  "dns",
+		},
+		{
+			address:   "foo1.bar2.com.gah.zip",
+			shouldErr: false,
+			protocol:  "dns",
+		},
+		{
+			address:   "hostname",
+			shouldErr: false,
+			protocol:  "dns",
+		},
+		{
+			address:   "",
+			shouldErr: true,
+		},
+		{
+			address:   "698.168.0.1",
+			shouldErr: true,
+		},
+		{
+			// Documenting that we do NOT support support certain things:
+			//
+			// While the Domain Name System (DNS) technically supports arbitrary sequences of octets in domain name labels,
+			// the DNS standards recommend the use of the LDH (letter-digit-hyphen) subset of ASCII conventionally used for
+			// host names, and require that string comparisons between DNS domain names should be case-insensitive.
+			//
+			// See => https://en.wikipedia.org/wiki/Punycode
+			address:   "例子.測試",
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		protocol, address, err := determineAddressProtocol(test.address)
+		if test.shouldErr {
+			require.Error(t, err)
+			break
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, test.address, address)
+		require.Equalf(t, test.protocol, protocol, "unexpected protocol for address: %s", test.address)
+	}
+}

--- a/node/notifiee.go
+++ b/node/notifiee.go
@@ -33,6 +33,7 @@ func (n *connectionNotifiee) Connected(network network.Network, conn network.Con
 		Str("peer", peerID.String()).
 		Str("remote_address", maddr.String()).
 		Str("local_address", laddr.String()).
+		Interface("addr_info", addrInfo).
 		Msg("peer connected")
 
 	// Store the peer info.


### PR DESCRIPTION
This PR makes some quality-of-life changes when it comes to node addressing and (re)connection.

Before, the IP address specified as the `dialback-address` would only accept an IPv4 address.. Now, the dialback address can be an IPv4, IPv6 or a DNS address. E.g. `node --dialback-address ch-0812201307.ddns.net --dialback-port 9000`.

Node with the advertised DNS address as the external/dialback one will connect to a peer via an IP address, but will indeed advertise it's DNS one too.

Log from a peer that connects to the DNS peer (note the `remote_address` and the `addr_info.Addrs` fields):

```json
{
  "level": "debug",
  "component": "notifiee",
  "peer": "12D3KooWKjoin2akBGR4JoBngj9xV7A1rKcujE7ERbBBbiHTRLfL",
  "remote_address": "/ip4/207.154.215.134/tcp/9000",
  "local_address": "/ip4/172.27.145.54/tcp/9000",
  "addr_info": {
    "ID": "12D3KooWKjoin2akBGR4JoBngj9xV7A1rKcujE7ERbBBbiHTRLfL",
    "Addrs": [
      "/dns4/ch-0812201307.ddns.net/tcp/9000",
      "/ip4/207.154.215.134/tcp/9000"
    ]
  },
  "time": "2023-08-02T07:48:17+02:00",
  "message": "peer connected"
}
```

Remote address is the _current_ IP of the node.

Another change is related to how we connect back to dialback peers on startup. Before, we always used the address the peer last connected from - in the example above, it would be the IPv4 address. But for a host with a dynamic IP address this one might change and that would fail. Now, we use all of the multiaddresses we're aware off (in the example above, both IPv4 and the DNS one). The DNS one should resolve to the _current_ IPv4 address and that should work.

It's also valid to specify the DNS address as the boot node, e.g. `/node --boot-nodes '/dns4/ch-0812201307.ddns.net/tcp/9000/p2p/12D3KooWKjoin2akBGR4JoBngj9xV7A1rKcujE7ERbBBbiHTRLfL'`.