### PR TITLE
Rename Go module: `blocklessnetworking` => `blocklessnetwork`

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -10,15 +10,15 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	"github.com/blocklessnetworking/b7s/api"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/api"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 const (
 	executeEndpoint = "/api/v1/functions/execute"
 	installEndpoint = "/api/v1/functions/install"
 	resultEndpoint  = "/api/v1/functions/requests/result"
-	healthEndpoint = "/api/v1/health"
+	healthEndpoint  = "/api/v1/health"
 )
 
 func setupAPI(t *testing.T) *api.API {

--- a/api/execute.go
+++ b/api/execute.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/node/aggregate"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/node/aggregate"
 )
 
 // ExecuteRequest describes the payload for the REST API request for function execution.

--- a/api/execute_test.go
+++ b/api/execute_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/api"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/api"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestAPI_Execute(t *testing.T) {

--- a/api/health.go
+++ b/api/health.go
@@ -3,14 +3,15 @@ package api
 import (
 	"net/http"
 
-	"github.com/blocklessnetworking/b7s/models/response"
 	"github.com/labstack/echo/v4"
+
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 // Execute implements the REST API endpoint for function execution.
 func (a *API) Health(ctx echo.Context) error {
 
-	// respond with health check	
+	// respond with health check
 	resp := response.Health{
 		Type: "health",
 		Code: http.StatusOK,

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 func TestAPI_HealthResult(t *testing.T) {

--- a/api/install_test.go
+++ b/api/install_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/api"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/api"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestAPI_FunctionInstall(t *testing.T) {

--- a/api/node.go
+++ b/api/node.go
@@ -3,8 +3,8 @@ package api
 import (
 	"context"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 type Node interface {

--- a/api/result_test.go
+++ b/api/result_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/api"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/api"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestAPI_ExecutionResult(t *testing.T) {

--- a/cmd/bootstrap-limiter/main.go
+++ b/cmd/bootstrap-limiter/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/pflag"
 
-	"github.com/blocklessnetworking/b7s/executor/limits"
+	"github.com/blocklessnetwork/b7s/executor/limits"
 )
 
 const (

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -3,8 +3,8 @@ package main
 import (
 	"github.com/spf13/pflag"
 
-	"github.com/blocklessnetworking/b7s/config"
-	"github.com/blocklessnetworking/b7s/node"
+	"github.com/blocklessnetwork/b7s/config"
+	"github.com/blocklessnetwork/b7s/node"
 )
 
 // Default values.

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -13,16 +13,16 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/ziflex/lecho/v3"
 
-	"github.com/blocklessnetworking/b7s/api"
-	"github.com/blocklessnetworking/b7s/config"
-	"github.com/blocklessnetworking/b7s/executor"
-	"github.com/blocklessnetworking/b7s/executor/limits"
-	"github.com/blocklessnetworking/b7s/fstore"
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/node"
-	"github.com/blocklessnetworking/b7s/peerstore"
-	"github.com/blocklessnetworking/b7s/store"
+	"github.com/blocklessnetwork/b7s/api"
+	"github.com/blocklessnetwork/b7s/config"
+	"github.com/blocklessnetwork/b7s/executor"
+	"github.com/blocklessnetwork/b7s/executor/limits"
+	"github.com/blocklessnetwork/b7s/fstore"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/node"
+	"github.com/blocklessnetwork/b7s/peerstore"
+	"github.com/blocklessnetwork/b7s/store"
 )
 
 const (

--- a/cmd/node/parse.go
+++ b/cmd/node/parse.go
@@ -3,7 +3,7 @@ package main
 import (
 	"errors"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 func parseNodeRole(role string) (blockless.NodeRole, error) {

--- a/executor/command.go
+++ b/executor/command.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // createCmd will create the command to be executed, prepare working directory, environment, standard input and all else.

--- a/executor/command_internal_test.go
+++ b/executor/command_internal_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestExecute_CreateCMD(t *testing.T) {

--- a/executor/config.go
+++ b/executor/config.go
@@ -3,7 +3,7 @@ package executor
 import (
 	"github.com/spf13/afero"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // defaultConfig used to create Executor.

--- a/executor/execute_function.go
+++ b/executor/execute_function.go
@@ -3,8 +3,8 @@ package executor
 import (
 	"fmt"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // ExecuteFunction will run the Blockless function defined by the execution request.

--- a/executor/execute_ux.go
+++ b/executor/execute_ux.go
@@ -9,8 +9,8 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/blocklessnetworking/b7s/executor/internal/process"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/executor/internal/process"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // executeCommand on non-windows systems is pretty straightforward and equivalent to the ordinary `cmd.Run()` or `cmd.Output`.

--- a/executor/execute_windows.go
+++ b/executor/execute_windows.go
@@ -11,8 +11,8 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"github.com/blocklessnetworking/b7s/executor/internal/process"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/executor/internal/process"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // executeCommand on Windows contains some dark sorcery. On Windows, the `rusage` equivalent does not include

--- a/executor/executor_integration_test.go
+++ b/executor/executor_integration_test.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/executor"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/executor"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 const (

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/executor"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/executor"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestExecutor_Create(t *testing.T) {

--- a/executor/internal/process/usage.go
+++ b/executor/internal/process/usage.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // GetUsage returns the resource usage information about the executed process.

--- a/executor/limiter.go
+++ b/executor/limiter.go
@@ -1,7 +1,7 @@
 package executor
 
 import (
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // noopLimiter is a dummy limiter used when processes run without any resource limitations.

--- a/executor/limits.go
+++ b/executor/limits.go
@@ -1,7 +1,7 @@
 package executor
 
 import (
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 type Limiter interface {

--- a/executor/limits/limits_gen.go
+++ b/executor/limits/limits_gen.go
@@ -6,7 +6,7 @@ package limits
 import (
 	"errors"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // NOTE: Placeholder for operating systems where we do not support limiters yet.

--- a/executor/limits/limits_linux.go
+++ b/executor/limits/limits_linux.go
@@ -12,7 +12,7 @@ import (
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup2"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // TODO: Add support for cgroups v1 - determine on the fly which version to use

--- a/executor/limits/limits_linux_integration_test.go
+++ b/executor/limits/limits_linux_integration_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/executor/limits"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/executor/limits"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 const (

--- a/executor/limits/limits_windows.go
+++ b/executor/limits/limits_windows.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 type Limits struct {

--- a/executor/limits/limits_windows_test.go
+++ b/executor/limits/limits_windows_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 
-	"github.com/blocklessnetworking/b7s/executor/limits"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/executor/limits"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 func TestLimits(t *testing.T) {

--- a/executor/path_internal_test.go
+++ b/executor/path_internal_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestExecutor_RequestPaths(t *testing.T) {

--- a/executor/runtime_flags.go
+++ b/executor/runtime_flags.go
@@ -3,7 +3,7 @@ package executor
 import (
 	"fmt"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // runtimeFlags returns flags that can be passed to the runtime, for example by `exec.Cmd`.

--- a/executor/runtime_flags_test.go
+++ b/executor/runtime_flags_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 func TestRuntimeFlags(t *testing.T) {

--- a/fstore/deployment.go
+++ b/fstore/deployment.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // updateDeployment info will add some missing information to the deployment info,

--- a/fstore/deployment_internal_test.go
+++ b/fstore/deployment_internal_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 func TestFunction_UpdateDeploymentInfo(t *testing.T) {

--- a/fstore/get.go
+++ b/fstore/get.go
@@ -3,7 +3,7 @@ package fstore
 import (
 	"fmt"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // Get retrieves a function manifest for the given function from storage.

--- a/fstore/get_test.go
+++ b/fstore/get_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/fstore"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/fstore"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestFunction_GetHandlesErrors(t *testing.T) {

--- a/fstore/gzip_internal_test.go
+++ b/fstore/gzip_internal_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/store"
-	"github.com/blocklessnetworking/b7s/testing/helpers"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/store"
+	"github.com/blocklessnetwork/b7s/testing/helpers"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestFunction_UnpackArchive(t *testing.T) {

--- a/fstore/http.go
+++ b/fstore/http.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cavaliergopher/grab/v3"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 func (h *FStore) getJSON(address string, out interface{}) error {

--- a/fstore/http_internal_test.go
+++ b/fstore/http_internal_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/store"
-	"github.com/blocklessnetworking/b7s/testing/helpers"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/store"
+	"github.com/blocklessnetwork/b7s/testing/helpers"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestFunction_GetJSON(t *testing.T) {

--- a/fstore/install.go
+++ b/fstore/install.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // Install will download and install function identified by the manifest/CID.

--- a/fstore/install_test.go
+++ b/fstore/install_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/fstore"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/store"
-	"github.com/blocklessnetworking/b7s/testing/helpers"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/fstore"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/store"
+	"github.com/blocklessnetwork/b7s/testing/helpers"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestFunction_Install(t *testing.T) {

--- a/fstore/record.go
+++ b/fstore/record.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 type functionRecord struct {

--- a/fstore/sync_internal_test.go
+++ b/fstore/sync_internal_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestFstore_CheckFunctionFiles(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/blocklessnetworking/b7s
+module github.com/blocklessnetwork/b7s
 
 go 1.19
 
 require (
 	github.com/Microsoft/go-winio v0.6.0
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cockroachdb/pebble v0.0.0-20220929203247-18d98601a233
 	github.com/containerd/cgroups/v3 v3.0.1
@@ -26,7 +27,6 @@ require (
 
 require (
 	github.com/armon/go-metrics v0.4.1 // indirect
-	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/host/config.go
+++ b/host/config.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/multiformats/go-multiaddr"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // defaultConfig used to create Host.

--- a/host/dht.go
+++ b/host/dht.go
@@ -12,7 +12,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/util"
 	"github.com/multiformats/go-multiaddr"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 func (h *Host) DiscoverPeers(ctx context.Context, topic string) error {

--- a/host/send.go
+++ b/host/send.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // SendMessage sends a message directly to the specified peer.

--- a/models/execute/response.go
+++ b/models/execute/response.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/codes"
 )
 
 // Result describes an execution result.

--- a/models/request/execute.go
+++ b/models/request/execute.go
@@ -3,7 +3,7 @@ package request
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // Execute describes the `MessageExecute` request payload.

--- a/models/response/execute.go
+++ b/models/response/execute.go
@@ -3,8 +3,8 @@ package response
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // Execute describes the response to the `MessageExecute` message.

--- a/models/response/form_cluster.go
+++ b/models/response/form_cluster.go
@@ -1,8 +1,9 @@
 package response
 
 import (
-	"github.com/blocklessnetworking/b7s/models/codes"
 	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetwork/b7s/models/codes"
 )
 
 // FormCluster describes the `MessageFormClusteRr` response.

--- a/models/response/install_function.go
+++ b/models/response/install_function.go
@@ -3,7 +3,7 @@ package response
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/codes"
 )
 
 // InstallFunction describes the response to the `MessageInstallFunction` message.

--- a/models/response/roll_call.go
+++ b/models/response/roll_call.go
@@ -3,7 +3,7 @@ package response
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/codes"
 )
 
 // RollCall describes the `MessageRollCall` response payload.

--- a/node/aggregate/aggregate.go
+++ b/node/aggregate/aggregate.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 type Results []Result

--- a/node/cluster.go
+++ b/node/cluster.go
@@ -8,10 +8,10 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 func (n *Node) processFormCluster(ctx context.Context, from peer.ID, payload []byte) error {

--- a/node/config.go
+++ b/node/config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/raft"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // Option can be used to set Node configuration options.

--- a/node/config_internal_test.go
+++ b/node/config_internal_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestConfig_NodeRole(t *testing.T) {

--- a/node/execute.go
+++ b/node/execute.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 func (n *Node) processExecute(ctx context.Context, from peer.ID, payload []byte) error {

--- a/node/execute_integration_test.go
+++ b/node/execute_integration_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 func TestNode_ExecuteComplete(t *testing.T) {

--- a/node/execute_internal_test.go
+++ b/node/execute_internal_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/models/response"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestNode_WorkerExecute(t *testing.T) {

--- a/node/executor.go
+++ b/node/executor.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 type Executor interface {

--- a/node/fsm.go
+++ b/node/fsm.go
@@ -9,7 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 type fsmLogEntry struct {

--- a/node/handlers.go
+++ b/node/handlers.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 // TODO: peerID of the sender is a good candidate to move on to the context

--- a/node/handlers_internal_test.go
+++ b/node/handlers_internal_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/models/response"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestNode_Handlers(t *testing.T) {

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []byte) error {

--- a/node/health.go
+++ b/node/health.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 // HealthPing will run a long running loop, publishing health signal until cancelled.

--- a/node/health_internal_test.go
+++ b/node/health_internal_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/response"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestNode_Health(t *testing.T) {

--- a/node/install.go
+++ b/node/install.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 func (n *Node) processInstallFunction(ctx context.Context, from peer.ID, payload []byte) error {

--- a/node/message_internal_test.go
+++ b/node/message_internal_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestNode_Messaging(t *testing.T) {

--- a/node/models.go
+++ b/node/models.go
@@ -1,8 +1,8 @@
 package node
 
 import (
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/request"
 )
 
 // convert the incoming message format to an execution request.

--- a/node/node.go
+++ b/node/node.go
@@ -10,9 +10,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog"
 
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/node/internal/waitmap"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/node/internal/waitmap"
 )
 
 // Node is the entity that actually provides the main Blockless node functionality.

--- a/node/node_integration_test.go
+++ b/node/node_integration_test.go
@@ -22,16 +22,16 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/executor"
-	"github.com/blocklessnetworking/b7s/fstore"
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/node"
-	"github.com/blocklessnetworking/b7s/peerstore"
-	"github.com/blocklessnetworking/b7s/store"
-	"github.com/blocklessnetworking/b7s/testing/helpers"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/executor"
+	"github.com/blocklessnetwork/b7s/fstore"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/node"
+	"github.com/blocklessnetwork/b7s/peerstore"
+	"github.com/blocklessnetwork/b7s/store"
+	"github.com/blocklessnetwork/b7s/testing/helpers"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 const (

--- a/node/node_internal_test.go
+++ b/node/node_internal_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 const (

--- a/node/notifiee_internal_test.go
+++ b/node/notifiee_internal_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestNode_Notifiee(t *testing.T) {

--- a/node/queue.go
+++ b/node/queue.go
@@ -3,7 +3,7 @@ package node
 import (
 	"sync"
 
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 type rollCallQueue struct {

--- a/node/queue_test.go
+++ b/node/queue_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/response"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestRollCallQueue(t *testing.T) {

--- a/node/raft.go
+++ b/node/raft.go
@@ -13,10 +13,10 @@ import (
 	libp2praft "github.com/libp2p/go-libp2p-raft"
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/log/hclog"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/log/hclog"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 type raftHandler struct {

--- a/node/rest.go
+++ b/node/rest.go
@@ -5,10 +5,10 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/request"
 )
 
 // ExecuteFunction can be used to start function execution. At the moment this is used by the API server to start execution on the head node.

--- a/node/rest_internal_test.go
+++ b/node/rest_internal_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestNode_RestExecuteNotSupportedOnWorker(t *testing.T) {

--- a/node/roll_call.go
+++ b/node/roll_call.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 func (n *Node) processRollCall(ctx context.Context, from peer.ID, payload []byte) error {

--- a/node/roll_call_internal_test.go
+++ b/node/roll_call_internal_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/host"
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/models/response"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/host"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestNode_RollCall(t *testing.T) {

--- a/node/run.go
+++ b/node/run.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/network"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // Run will start the main loop for the node.

--- a/node/sync_internal_test.go
+++ b/node/sync_internal_test.go
@@ -3,9 +3,10 @@ package node
 import (
 	"testing"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func TestNode_Sync(t *testing.T) {

--- a/node/worker_execute.go
+++ b/node/worker_execute.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
-	"github.com/blocklessnetworking/b7s/models/request"
-	"github.com/blocklessnetworking/b7s/models/response"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
 
 func (n *Node) workerProcessExecute(ctx context.Context, from peer.ID, payload []byte) error {

--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -6,7 +6,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // PeerStore takes care of storing and reading peer information to and from persistent storage.

--- a/peerstore/peerstore_test.go
+++ b/peerstore/peerstore_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/peerstore"
-	"github.com/blocklessnetworking/b7s/store"
-	"github.com/blocklessnetworking/b7s/testing/helpers"
-	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/blocklessnetwork/b7s/peerstore"
+	"github.com/blocklessnetwork/b7s/store"
+	"github.com/blocklessnetwork/b7s/testing/helpers"
+	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
 func Test_PeerStore(t *testing.T) {

--- a/store/get.go
+++ b/store/get.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 // Get retrieves the value for a key.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/store"
-	"github.com/blocklessnetworking/b7s/testing/helpers"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/store"
+	"github.com/blocklessnetwork/b7s/testing/helpers"
 )
 
 func Test_Store(t *testing.T) {

--- a/testing/helpers/function_server.go
+++ b/testing/helpers/function_server.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 type FunctionServer struct {

--- a/testing/mocks/executor.go
+++ b/testing/mocks/executor.go
@@ -3,7 +3,7 @@ package mocks
 import (
 	"testing"
 
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 type Executor struct {

--- a/testing/mocks/fstore.go
+++ b/testing/mocks/fstore.go
@@ -3,7 +3,7 @@ package mocks
 import (
 	"testing"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 type FStore struct {

--- a/testing/mocks/generic.go
+++ b/testing/mocks/generic.go
@@ -8,9 +8,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // Global variables that can be used for testing. They are valid non-nil values for commonly needed types.

--- a/testing/mocks/node.go
+++ b/testing/mocks/node.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/blocklessnetworking/b7s/models/codes"
-	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/codes"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
 // Node implements the `Node` interface expected by the API.

--- a/testing/mocks/peerstore.go
+++ b/testing/mocks/peerstore.go
@@ -6,7 +6,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 
-	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 type PeerStore struct {


### PR DESCRIPTION
Renaming Go module so it matches the Github repo URL