### PR TITLE
PBFT specific execution result processing + signing

### DIFF
--- a/consensus/pbft/core.go
+++ b/consensus/pbft/core.go
@@ -42,6 +42,12 @@ func (c pbftCore) commitQuorum() uint {
 	return 2*c.f + 1
 }
 
+// MinClusterResults returns the number of identical results client should expect from the
+// cluster before accepting the result as valid. The number is f+1.
+func MinClusterResults(n uint) uint {
+	return calcByzantineTolerance(n) + 1
+}
+
 // based on the number of replicas, determine how many byzantine replicas we can tolerate.
 func calcByzantineTolerance(n uint) uint {
 

--- a/models/execute/response.go
+++ b/models/execute/response.go
@@ -28,7 +28,7 @@ type RuntimeOutput struct {
 	Stdout   string `json:"stdout"`
 	Stderr   string `json:"stderr"`
 	ExitCode int    `json:"exit_code"`
-	Log      string `json:"-"` // TODO: Check do we want to send this over the wire too?
+	Log      string `json:"-"`
 }
 
 // Usage represents the resource usage information for a particular execution.

--- a/models/response/execute.go
+++ b/models/response/execute.go
@@ -34,7 +34,7 @@ type Execute struct {
 type PBFTResultInfo struct {
 	View             uint      `json:"view"`
 	RequestTimestamp time.Time `json:"request_timestamp,omitempty"`
-	Replica          peer.ID   `json:"replica"`
+	Replica          peer.ID   `json:"replica,omitempty"`
 }
 
 func (e *Execute) Sign(key crypto.PrivKey) error {

--- a/models/response/execute.go
+++ b/models/response/execute.go
@@ -1,6 +1,13 @@
 package response
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/blocklessnetworking/b7s/models/codes"
@@ -16,6 +23,66 @@ type Execute struct {
 	Results   execute.ResultMap `json:"results,omitempty"`
 	Cluster   execute.Cluster   `json:"cluster,omitempty"`
 
+	PBFT PBFTResultInfo `json:"pbft,omitempty"`
+	// Signed digest of the response.
+	Signature string `json:"signature,omitempty"`
+
 	// Used to communicate the reason for failure to the user.
 	Message string `json:"message,omitempty"`
+}
+
+type PBFTResultInfo struct {
+	View             uint      `json:"view"`
+	RequestTimestamp time.Time `json:"request_timestamp,omitempty"`
+	Replica          peer.ID   `json:"replica"`
+}
+
+func (e *Execute) Sign(key crypto.PrivKey) error {
+
+	// Exclude signature and the `from` field from the signature.
+	cp := *e
+	cp.Signature = ""
+	cp.From = ""
+
+	payload, err := json.Marshal(cp)
+	if err != nil {
+		return fmt.Errorf("could not get byte representation of the record: %w", err)
+	}
+
+	sig, err := key.Sign(payload)
+	if err != nil {
+		return fmt.Errorf("could not sign digest: %w", err)
+	}
+
+	e.Signature = hex.EncodeToString(sig)
+	return nil
+}
+
+func (e Execute) VerifySignature(key crypto.PubKey) error {
+
+	// Exclude signature and the `from` field from the signature.
+	cp := e
+	cp.Signature = ""
+	cp.From = ""
+
+	payload, err := json.Marshal(cp)
+	if err != nil {
+		return fmt.Errorf("could not get byte representation of the record: %w", err)
+	}
+
+	sig, err := hex.DecodeString(e.Signature)
+	if err != nil {
+		return fmt.Errorf("could not decode signature from hex: %w", err)
+	}
+
+	ok, err := key.Verify(payload, sig)
+	if err != nil {
+		return fmt.Errorf("could not verify signature: %w", err)
+	}
+
+	if !ok {
+		return errors.New("invalid signature")
+	}
+
+	return nil
 }

--- a/models/response/execute_test.go
+++ b/models/response/execute_test.go
@@ -1,0 +1,67 @@
+package response
+
+import (
+	"testing"
+
+	"github.com/blocklessnetworking/b7s/host"
+	"github.com/blocklessnetworking/b7s/models/blockless"
+	"github.com/blocklessnetworking/b7s/models/codes"
+	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetworking/b7s/testing/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecute_Signing(t *testing.T) {
+
+	sampleRes := Execute{
+		Type:      blockless.MessageExecuteResponse,
+		RequestID: mocks.GenericUUID.String(),
+		From:      mocks.GenericPeerID,
+		Code:      codes.OK,
+		Results: execute.ResultMap{
+			mocks.GenericPeerID: mocks.GenericExecutionResult,
+		},
+		Cluster: execute.Cluster{
+			Peers: mocks.GenericPeerIDs[:4],
+		},
+	}
+
+	t.Run("nominal case", func(t *testing.T) {
+
+		res := sampleRes
+		host, err := host.New(mocks.NoopLogger, "127.0.0.1", 0)
+		require.NoError(t, err)
+
+		err = res.Sign(host.PrivateKey())
+		require.NoError(t, err)
+
+		err = res.VerifySignature(host.PublicKey())
+		require.NoError(t, err)
+	})
+	t.Run("empty signature verification fails", func(t *testing.T) {
+
+		res := sampleRes
+		res.Signature = ""
+
+		host, err := host.New(mocks.NoopLogger, "127.0.0.1", 0)
+		require.NoError(t, err)
+
+		err = res.VerifySignature(host.PublicKey())
+		require.Error(t, err)
+	})
+	t.Run("tampered data signature verification fails", func(t *testing.T) {
+
+		res := sampleRes
+		host, err := host.New(mocks.NoopLogger, "127.0.0.1", 0)
+		require.NoError(t, err)
+
+		err = res.Sign(host.PrivateKey())
+		require.NoError(t, err)
+
+		res.RequestID += " "
+
+		err = res.VerifySignature(host.PublicKey())
+		require.Error(t, err)
+	})
+
+}

--- a/node/execute.go
+++ b/node/execute.go
@@ -28,7 +28,7 @@ func (n *Node) processExecuteResponse(ctx context.Context, from peer.ID, payload
 	var res response.Execute
 	err := json.Unmarshal(payload, &res)
 	if err != nil {
-		return fmt.Errorf("could not not unpack execute response: %w", err)
+		return fmt.Errorf("could not unpack execute response: %w", err)
 	}
 	res.From = from
 

--- a/node/execution_results.go
+++ b/node/execution_results.go
@@ -1,0 +1,143 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/rs/zerolog/log"
+
+	"github.com/blocklessnetworking/b7s/consensus/pbft"
+	"github.com/blocklessnetworking/b7s/models/execute"
+	"github.com/blocklessnetworking/b7s/models/response"
+)
+
+// gatherExecutionResultsPBFT collects execution results from a PBFT cluster. This means f+1 identical results.
+func (n *Node) gatherExecutionResultsPBFT(ctx context.Context, requestID string, peers []peer.ID) execute.ResultMap {
+
+	exctx, exCancel := context.WithTimeout(ctx, n.cfg.ExecutionTimeout)
+	defer exCancel()
+
+	type aggregatedResult struct {
+		result execute.Result
+		peers  []peer.ID
+	}
+
+	var (
+		count = pbft.MinClusterResults(uint(len(peers)))
+		lock  sync.Mutex
+		wg    sync.WaitGroup
+
+		results = make(map[string]aggregatedResult)
+	)
+
+	wg.Add(len(peers))
+
+	for _, rp := range peers {
+		go func(sender peer.ID) {
+			defer wg.Done()
+
+			key := executionResultKey(requestID, sender)
+			res, ok := n.executeResponses.WaitFor(exctx, key)
+			if !ok {
+				return
+			}
+
+			n.log.Info().Str("peer", sender.String()).Str("request", requestID).Msg("accounted execution response from peer")
+
+			er := res.(response.Execute)
+
+			pub, err := sender.ExtractPublicKey()
+			if err != nil {
+				log.Error().Err(err).Msg("could not derive public key from peer ID")
+				return
+			}
+
+			err = er.VerifySignature(pub)
+			if err != nil {
+				log.Error().Err(err).Msg("could not verify signature of an execution response")
+				return
+			}
+
+			exres, ok := er.Results[sender]
+			if !ok {
+				return
+			}
+
+			lock.Lock()
+			defer lock.Unlock()
+
+			// Equality means same result and same timestamp.
+			reskey := fmt.Sprintf("%+#v-%s", exres.Result, er.PBFT.RequestTimestamp.String())
+			result, ok := results[reskey]
+			if !ok {
+				results[reskey] = aggregatedResult{
+					result: exres,
+					peers: []peer.ID{
+						sender,
+					},
+				}
+				return
+			}
+
+			result.peers = append(result.peers, sender)
+			if uint(len(result.peers)) >= count {
+				n.log.Info().Str("request", requestID).Int("peers", len(peers)).Uint("matching_results", count).Msg("have enough maching results")
+				exCancel()
+				return
+			}
+		}(rp)
+	}
+
+	wg.Wait()
+
+	return execute.ResultMap{}
+}
+
+// gatherExecutionResults collects execution results from direct executions or raft clusters.
+func (n *Node) gatherExecutionResults(ctx context.Context, requestID string, peers []peer.ID) execute.ResultMap {
+
+	// We're willing to wait for a limited amount of time.
+	exctx, exCancel := context.WithTimeout(ctx, n.cfg.ExecutionTimeout)
+	defer exCancel()
+
+	var (
+		results execute.ResultMap = make(map[peer.ID]execute.Result)
+		reslock sync.Mutex
+		wg      sync.WaitGroup
+	)
+
+	wg.Add(len(peers))
+
+	// Wait on peers asynchronously.
+	for _, rp := range peers {
+		rp := rp
+
+		go func() {
+			defer wg.Done()
+			key := executionResultKey(requestID, rp)
+			res, ok := n.executeResponses.WaitFor(exctx, key)
+			if !ok {
+				return
+			}
+
+			log.Info().Str("peer", rp.String()).Msg("accounted execution response from peer")
+
+			er := res.(response.Execute)
+
+			exres, ok := er.Results[rp]
+			if !ok {
+				return
+			}
+
+			reslock.Lock()
+			defer reslock.Unlock()
+			results[rp] = exres
+		}()
+	}
+
+	wg.Wait()
+
+	return results
+}

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/blocklessnetworking/b7s/consensus"
 	"github.com/blocklessnetworking/b7s/models/blockless"
 	"github.com/blocklessnetworking/b7s/models/codes"
 	"github.com/blocklessnetworking/b7s/models/execute"
@@ -75,19 +75,19 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 		nodeCount = req.Config.NodeCount
 	}
 
-	consensus, err := parseConsensusAlgorithm(req.Config.ConsensusAlgorithm)
+	consensusAlgo, err := parseConsensusAlgorithm(req.Config.ConsensusAlgorithm)
 	if err != nil {
 		n.log.Error().Str("value", req.Config.ConsensusAlgorithm).Str("default", n.cfg.DefaultConsensus.String()).Err(err).Msg("could not parse consensus algorithm from the user request, using default")
-		consensus = n.cfg.DefaultConsensus
+		consensusAlgo = n.cfg.DefaultConsensus
 	}
 
 	// Create a logger with relevant context.
-	log := n.log.With().Str("request", requestID).Str("function", req.FunctionID).Int("node_count", nodeCount).Str("consenus", consensus.String()).Logger()
+	log := n.log.With().Str("request", requestID).Str("function", req.FunctionID).Int("node_count", nodeCount).Str("consenus", consensusAlgo.String()).Logger()
 
 	log.Info().Msg("processing execution request")
 
 	// Phase 1. - Issue roll call to nodes.
-	reportingPeers, err := n.executeRollCall(ctx, requestID, req.FunctionID, nodeCount, consensus)
+	reportingPeers, err := n.executeRollCall(ctx, requestID, req.FunctionID, nodeCount, consensusAlgo)
 	if err != nil {
 		code := codes.Error
 		if errors.Is(err, blockless.ErrRollCallTimeout) {
@@ -104,9 +104,9 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 	}
 
 	// Phase 2. - Request cluster formation, if we need consensus.
-	if consensusRequired(consensus) {
+	if consensusRequired(consensusAlgo) {
 
-		err := n.formCluster(ctx, requestID, reportingPeers, consensus)
+		err := n.formCluster(ctx, requestID, reportingPeers, consensusAlgo)
 		if err != nil {
 			return codes.Error, nil, execute.Cluster{}, fmt.Errorf("could not form cluster (request: %s): %w", requestID, err)
 		}
@@ -138,47 +138,13 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 
 	log.Debug().Msg("waiting for execution responses")
 
-	// We're willing to wait for a limited amount of time.
-	exctx, exCancel := context.WithTimeout(ctx, n.cfg.ExecutionTimeout)
-	defer exCancel()
+	var results execute.ResultMap
+	if consensusAlgo == consensus.PBFT {
+		results = n.gatherExecutionResultsPBFT(ctx, requestID, reportingPeers)
 
-	var (
-		// We're waiting for a single execution result now, as only the cluster leader will return a result.
-		results execute.ResultMap = make(map[peer.ID]execute.Result)
-		reslock sync.Mutex
-		wg      sync.WaitGroup
-	)
-
-	wg.Add(len(reportingPeers))
-
-	// Wait on peers asynchronously.
-	for _, rp := range reportingPeers {
-		rp := rp
-
-		go func() {
-			defer wg.Done()
-			key := executionResultKey(requestID, rp)
-			res, ok := n.executeResponses.WaitFor(exctx, key)
-			if !ok {
-				return
-			}
-
-			log.Info().Str("peer", rp.String()).Msg("accounted execution response from peer")
-
-			er := res.(response.Execute)
-
-			exres, ok := er.Results[rp]
-			if !ok {
-				return
-			}
-
-			reslock.Lock()
-			defer reslock.Unlock()
-			results[rp] = exres
-		}()
 	}
 
-	wg.Wait()
+	results = n.gatherExecutionResults(ctx, requestID, reportingPeers)
 
 	log.Info().Int("cluster_size", len(reportingPeers)).Int("responded", len(results)).Msg("received execution responses")
 


### PR DESCRIPTION
This PR changes our handling of PBFT execution results. Instead of waiting for ALL execution results, we wait for `f+1` matching results. This should also reduce latency slightly as we'll take (in an optimistic case) first two results and run with them.

We also introduce result signing.

For Raft and direct execution, we still wait for all peers to report back.