### PR TITLE
change key format

### DIFF
--- a/cmd/keyforge/key_management.go
+++ b/cmd/keyforge/key_management.go
@@ -18,7 +18,7 @@ func LoadOrCreateKeys(privKeyFile string, outputDir string) (crypto.PrivKey, cry
 	var err error
 
 	if _, err := os.Stat(privKeyFile); os.IsNotExist(err) {
-		priv, pub, err = crypto.GenerateKeyPair(crypto.Ed25519, 0)
+		priv, pub, err = crypto.GenerateKeyPair(crypto.ECDSA, 0)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
small change to use ECDSA keys for node key/pairs. Ethereum doesn't have Ed25519 precompile, so this is an expensive check.