### PR TITLE
Use ecdsa keys

### DIFF
--- a/cmd/keyforge/ecdsa_management.go
+++ b/cmd/keyforge/ecdsa_management.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// LoadOrCreateECDSAKeys loads existing ECDSA keys or creates new ones if not present
+func LoadOrCreateECDSAKeys(ecdsaPrivKeyFile string, outputDir string) (crypto.PrivKey, crypto.PubKey, error) {
+	var priv crypto.PrivKey
+	var pub crypto.PubKey
+	var err error
+
+	if _, err := os.Stat(ecdsaPrivKeyFile); os.IsNotExist(err) {
+		priv, pub, err = crypto.GenerateKeyPair(crypto.ECDSA, 256)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		privBytes, err := ioutil.ReadFile(ecdsaPrivKeyFile)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		priv, err = crypto.UnmarshalPrivateKey(privBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		pub = priv.GetPublic()
+	}
+
+	privPayload, err := crypto.MarshalPrivateKey(priv)
+	if err != nil {
+		log.Fatalf("Could not marshal private ECDSA key: %s", err)
+	}
+
+	pubPayload, err := crypto.MarshalPublicKey(pub)
+	if err != nil {
+		log.Fatalf("Could not marshal public ECDSA key: %s", err)
+	}
+
+	identity, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		log.Fatalf("Could not generate identity: %s", err)
+	}
+
+	ecdsaPubKeyFile := filepath.Join(outputDir, ecdsaPubKeyName)
+	err = ioutil.WriteFile(ecdsaPubKeyFile, pubPayload, ecdsaPubKeyPermissions)
+	if err != nil {
+		log.Fatalf("Could not write public ECDSA key to file: %s", err)
+	}
+
+	ecdsaPubKeyTextFile := filepath.Join(outputDir, ecdsaPubKeyTxtName)
+	ecdsaPubKeyBase64 := base64.StdEncoding.EncodeToString(pubPayload)
+	err = ioutil.WriteFile(ecdsaPubKeyTextFile, []byte(ecdsaPubKeyBase64), ecdsaPubKeyPermissions)
+	if err != nil {
+		log.Fatalf("Could not write public ECDSA key text to file: %s", err)
+	}
+
+	ecdsaIdentityFile := filepath.Join(outputDir, ecdsaIdentityName)
+	err = ioutil.WriteFile(ecdsaIdentityFile, []byte(identity.Pretty()), ecdsaPubKeyPermissions)
+	if err != nil {
+		log.Fatalf("Could not write identity to file: %s", err)
+	}
+
+	ecdsaPrivKeyFilePath := filepath.Join(outputDir, ecdsaPrivKeyName)
+	err = ioutil.WriteFile(ecdsaPrivKeyFilePath, privPayload, ecdsaPrivKeyPermissions)
+	if err != nil {
+		log.Fatalf("Could not write private ECDSA key to file: %s", err)
+	}
+
+	ecdsaPeerIDFile := filepath.Join(outputDir, ecdsaPeerIDFileName)
+	err = ioutil.WriteFile(ecdsaPeerIDFile, []byte(identity.Pretty()), ecdsaPubKeyPermissions)
+	if err != nil {
+		log.Fatalf("Could not write peer ID to file: %s", err)
+	}
+
+	return priv, pub, nil
+}

--- a/cmd/keyforge/key_management.go
+++ b/cmd/keyforge/key_management.go
@@ -17,7 +17,7 @@ func LoadOrCreateKeys(privKeyFile string, outputDir string) (crypto.PrivKey, cry
 	var err error
 
 	if _, err := os.Stat(privKeyFile); os.IsNotExist(err) {
-		priv, pub, err = crypto.GenerateKeyPair(crypto.Ed25519, 0)
+		priv, pub, err = crypto.GenerateKeyPair(crypto.ECDSA, 0)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/keyforge/main.go
+++ b/cmd/keyforge/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/spf13/pflag"
 )
 
@@ -16,6 +17,15 @@ const (
 	peerIDFileName     = "peerid.txt"
 	privKeyPermissions = 0600
 	pubKeyPermissions  = 0644
+
+	// ECDSA constants
+	ecdsaPrivKeyName        = "ecdsaPrivKey.bin"
+	ecdsaPubKeyName         = "ecdsaPubKey.bin"
+	ecdsaPubKeyTxtName      = "ecdsaPubKey.txt"
+	ecdsaIdentityName       = "ecdsaIdentity"
+	ecdsaPeerIDFileName     = "ecdsaPeerID.txt"
+	ecdsaPrivKeyPermissions = 0600
+	ecdsaPubKeyPermissions  = 0644
 )
 
 func main() {
@@ -27,6 +37,7 @@ func main() {
 		flagMessage   string
 		flagSignature string
 		flagPeerID    string
+		flagUseECDSA bool
 	)
 
 	pflag.StringVar(&flagPeerID, "peerid", "", "PeerID for verification")
@@ -36,6 +47,7 @@ func main() {
 	pflag.StringVar(&flagPublicKey, "pubkey", "", "Base64 encoded public key for verification")
 	pflag.StringVar(&flagMessage, "message", "", "The original message to verify")
 	pflag.StringVar(&flagSignature, "signature", "", "Base64 encoded signature to verify")
+	pflag.BoolVar(&flagUseECDSA, "ecdsa", false, "Use ECDSA keys instead of the default")
 
 	pflag.Parse()
 
@@ -45,15 +57,31 @@ func main() {
 		log.Fatalf("Could not create output directory: %s", err)
 	}
 
-	privKeyFile := filepath.Join(flagOutputDir, privKeyName)
+	var priv, pub interface{}  // use interface{} if the key types are different
+	var privKeyFile string
 
-	priv, pub, err := LoadOrCreateKeys(privKeyFile, flagOutputDir)
+	if flagUseECDSA {
+		privKeyFile = filepath.Join(flagOutputDir, ecdsaPrivKeyName)
+		priv, pub, err = LoadOrCreateECDSAKeys(privKeyFile, flagOutputDir)
+	} else {
+		privKeyFile = filepath.Join(flagOutputDir, privKeyName)
+		priv, pub, err = LoadOrCreateKeys(privKeyFile, flagOutputDir)
+	}
+	
 	if err != nil {
 		log.Fatalf("Error loading or creating keys: %s", err)
 	}
 
 	if flagString != "" || flagFile != "" {
-		HandleSignAndVerify(priv, pub, flagString, flagFile, flagOutputDir)
+		if privKey, ok := priv.(crypto.PrivKey); ok {
+			if pubKey, ok := pub.(crypto.PubKey); ok {
+				HandleSignAndVerify(privKey, pubKey, flagString, flagFile, flagOutputDir)
+			} else {
+				log.Fatal("pub is not a valid crypto.PubKey")
+			}
+		} else {
+			log.Fatal("priv is not a valid crypto.PrivKey")
+		}
 	}
 
 	if flagPublicKey != "" && flagMessage != "" && flagSignature != "" {

--- a/cmd/keyforge/main.go
+++ b/cmd/keyforge/main.go
@@ -17,7 +17,6 @@ const (
 	peerIDFileName     = "peerid.txt"
 	privKeyPermissions = 0600
 	pubKeyPermissions  = 0644
-
 	// ECDSA constants
 	ecdsaPrivKeyName        = "ecdsaPrivKey.bin"
 	ecdsaPubKeyName         = "ecdsaPubKey.bin"


### PR DESCRIPTION
adds support for using ECDSA keys that are 256bit, we generate a new set of keys with these signatures. Currently not secured with the IPFS key, but I think we will likely go that route.