### PR TITLE
logs out api port

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -241,7 +241,7 @@ func run() int {
 		// Start API in a separate goroutine.
 		go func() {
 
-			log.Info().Msg("Node API starting")
+			log.Info().Str("port", cfg.API).Msg("Node API starting")
 			err := server.Start(cfg.API)
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				log.Warn().Err(err).Msg("Node API failed")


### PR DESCRIPTION
small change to have the node log it's RPC port, so we can pick it up in the CLI, or Logs.