### PR TITLE
Adding support for multiple subgroups

### DIFF
--- a/api/execute.go
+++ b/api/execute.go
@@ -16,7 +16,7 @@ import (
 // ExecuteRequest describes the payload for the REST API request for function execution.
 type ExecuteRequest struct {
 	execute.Request
-	Topic string `json:"topic,omitempty"`
+	Subgroup string `json:"subgroup,omitempty"`
 }
 
 // ExecuteResponse describes the REST API response for function execution.
@@ -47,7 +47,7 @@ func (a *API) Execute(ctx echo.Context) error {
 	}
 
 	// Get the execution result.
-	code, id, results, cluster, err := a.Node.ExecuteFunction(ctx.Request().Context(), execute.Request(req.Request), req.Topic)
+	code, id, results, cluster, err := a.Node.ExecuteFunction(ctx.Request().Context(), execute.Request(req.Request), req.Subgroup)
 	if err != nil {
 		a.Log.Warn().Str("function", req.FunctionID).Err(err).Msg("node failed to execute function")
 	}

--- a/api/execute.go
+++ b/api/execute.go
@@ -14,7 +14,10 @@ import (
 )
 
 // ExecuteRequest describes the payload for the REST API request for function execution.
-type ExecuteRequest execute.Request
+type ExecuteRequest struct {
+	execute.Request
+	Topic string `json:"topic,omitempty"`
+}
 
 // ExecuteResponse describes the REST API response for function execution.
 type ExecuteResponse struct {
@@ -44,7 +47,7 @@ func (a *API) Execute(ctx echo.Context) error {
 	}
 
 	// Get the execution result.
-	code, id, results, cluster, err := a.Node.ExecuteFunction(ctx.Request().Context(), execute.Request(req))
+	code, id, results, cluster, err := a.Node.ExecuteFunction(ctx.Request().Context(), execute.Request(req.Request), req.Topic)
 	if err != nil {
 		a.Log.Warn().Str("function", req.FunctionID).Err(err).Msg("node failed to execute function")
 	}

--- a/api/execute_test.go
+++ b/api/execute_test.go
@@ -31,7 +31,7 @@ func TestAPI_Execute(t *testing.T) {
 	expectedCode := codes.OK
 
 	node := mocks.BaselineNode(t)
-	node.ExecuteFunctionFunc = func(context.Context, execute.Request) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
+	node.ExecuteFunctionFunc = func(context.Context, execute.Request, string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
 
 		res := execute.ResultMap{
 			mocks.GenericPeerID: executionResult,
@@ -85,7 +85,7 @@ func TestAPI_Execute_HandlesErrors(t *testing.T) {
 	expectedCode := codes.Error
 
 	node := mocks.BaselineNode(t)
-	node.ExecuteFunctionFunc = func(context.Context, execute.Request) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
+	node.ExecuteFunctionFunc = func(context.Context, execute.Request, string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
 
 		res := execute.ResultMap{
 			mocks.GenericPeerID: executionResult,

--- a/api/install.go
+++ b/api/install.go
@@ -17,8 +17,9 @@ const (
 
 // InstallFunctionRequest describes the payload for the REST API request for function install.
 type InstallFunctionRequest struct {
-	CID string `json:"cid"`
-	URI string `json:"uri"`
+	CID   string `json:"cid"`
+	URI   string `json:"uri"`
+	Topic string `json:"topic"`
 }
 
 // InstallFunctionResponse describes the REST API response for the function install.
@@ -46,7 +47,7 @@ func (a *API) Install(ctx echo.Context) error {
 	// Start function install in a separate goroutine and signal when it's done.
 	fnErr := make(chan error)
 	go func() {
-		err = a.Node.PublishFunctionInstall(reqCtx, req.URI, req.CID)
+		err = a.Node.PublishFunctionInstall(reqCtx, req.URI, req.CID, req.Topic)
 		fnErr <- err
 	}()
 

--- a/api/install.go
+++ b/api/install.go
@@ -17,9 +17,9 @@ const (
 
 // InstallFunctionRequest describes the payload for the REST API request for function install.
 type InstallFunctionRequest struct {
-	CID   string `json:"cid"`
-	URI   string `json:"uri"`
-	Topic string `json:"topic"`
+	CID      string `json:"cid"`
+	URI      string `json:"uri"`
+	Subgroup string `json:"subgroup"`
 }
 
 // InstallFunctionResponse describes the REST API response for the function install.
@@ -47,7 +47,7 @@ func (a *API) Install(ctx echo.Context) error {
 	// Start function install in a separate goroutine and signal when it's done.
 	fnErr := make(chan error)
 	go func() {
-		err = a.Node.PublishFunctionInstall(reqCtx, req.URI, req.CID, req.Topic)
+		err = a.Node.PublishFunctionInstall(reqCtx, req.URI, req.CID, req.Subgroup)
 		fnErr <- err
 	}()
 

--- a/api/install_test.go
+++ b/api/install_test.go
@@ -67,7 +67,7 @@ func TestAPI_FunctionInstall_HandlesErrors(t *testing.T) {
 		)
 
 		node := mocks.BaselineNode(t)
-		node.PublishFunctionInstallFunc = func(context.Context, string, string) error {
+		node.PublishFunctionInstallFunc = func(context.Context, string, string, string) error {
 			time.Sleep(installDuration)
 			return nil
 		}
@@ -99,7 +99,7 @@ func TestAPI_FunctionInstall_HandlesErrors(t *testing.T) {
 		t.Parallel()
 
 		node := mocks.BaselineNode(t)
-		node.PublishFunctionInstallFunc = func(context.Context, string, string) error {
+		node.PublishFunctionInstallFunc = func(context.Context, string, string, string) error {
 			return mocks.GenericError
 		}
 

--- a/api/node.go
+++ b/api/node.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Node interface {
-	ExecuteFunction(ctx context.Context, req execute.Request, topic string) (code codes.Code, requestID string, results execute.ResultMap, peers execute.Cluster, err error)
+	ExecuteFunction(ctx context.Context, req execute.Request, subgroup string) (code codes.Code, requestID string, results execute.ResultMap, peers execute.Cluster, err error)
 	ExecutionResult(id string) (execute.Result, bool)
 	PublishFunctionInstall(ctx context.Context, uri string, cid string, topic string) error
 }

--- a/api/node.go
+++ b/api/node.go
@@ -10,5 +10,5 @@ import (
 type Node interface {
 	ExecuteFunction(ctx context.Context, req execute.Request, subgroup string) (code codes.Code, requestID string, results execute.ResultMap, peers execute.Cluster, err error)
 	ExecutionResult(id string) (execute.Result, bool)
-	PublishFunctionInstall(ctx context.Context, uri string, cid string, topic string) error
+	PublishFunctionInstall(ctx context.Context, uri string, cid string, subgroup string) error
 }

--- a/api/node.go
+++ b/api/node.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Node interface {
-	ExecuteFunction(context.Context, execute.Request) (code codes.Code, requestID string, results execute.ResultMap, peers execute.Cluster, err error)
+	ExecuteFunction(ctx context.Context, req execute.Request, topic string) (code codes.Code, requestID string, results execute.ResultMap, peers execute.Cluster, err error)
 	ExecutionResult(id string) (execute.Result, bool)
-	PublishFunctionInstall(ctx context.Context, uri string, cid string) error
+	PublishFunctionInstall(ctx context.Context, uri string, cid string, topic string) error
 }

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -33,7 +33,7 @@ func parseFlags() *config.Config {
 	pflag.StringVar(&cfg.API, "rest-api", "", "address where the head node REST API will listen on")
 	pflag.StringVar(&cfg.Workspace, "workspace", "./workspace", "directory that the node can use for file storage")
 	pflag.StringVar(&cfg.RuntimePath, "runtime-path", "", "runtime path (used by the worker node)")
-	pflag.StringVar(&cfg.RuntimeCLI, "runtime-cli", "", "runtime path (used by the worker node)")
+	pflag.StringVar(&cfg.RuntimeCLI, "runtime-cli", "", "runtime CLI name (used by the worker node)")
 	pflag.BoolVar(&cfg.LoadAttributes, "attributes", false, "node should try to load its attribute data from IPFS")
 	pflag.StringSliceVar(&cfg.Topics, "topic", nil, "topics node should subscribe to")
 

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -35,6 +35,7 @@ func parseFlags() *config.Config {
 	pflag.StringVar(&cfg.RuntimePath, "runtime-path", "", "runtime path (used by the worker node)")
 	pflag.StringVar(&cfg.RuntimeCLI, "runtime-cli", "", "runtime path (used by the worker node)")
 	pflag.BoolVar(&cfg.LoadAttributes, "attributes", false, "node should try to load its attribute data from IPFS")
+	pflag.StringSliceVar(&cfg.Topics, "topic", nil, "topics node should subscribe to")
 
 	// Host configuration.
 	pflag.StringVar(&cfg.Host.PrivateKey, "private-key", "", "private key that the b7s host will use")

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -157,7 +157,7 @@ func run() int {
 		executor, err := executor.New(log, execOptions...)
 		if err != nil {
 			log.Error().
-			Err(err).
+				Err(err).
 				Str("workspace", cfg.Workspace).
 				Str("runtime_path", cfg.RuntimePath).
 				Msg("could not create an executor")
@@ -180,6 +180,11 @@ func run() int {
 
 	// Create function store.
 	fstore := fstore.New(log, functionStore, cfg.Workspace)
+
+	// If we have topics specified, use those.
+	if len(cfg.Topics) > 0 {
+		opts = append(opts, node.WithTopics(cfg.Topics))
+	}
 
 	// Instantiate node.
 	node, err := node.New(log, host, peerstore, fstore, opts...)

--- a/config/model.go
+++ b/config/model.go
@@ -8,12 +8,13 @@ type Config struct {
 	Role                 string
 	BootNodes            []string
 	Concurrency          uint
+	Topics               []string
 
-	Host            Host
-	API             string
-	RuntimePath     string
-	RuntimeCLI 		string
-	LoadAttributes  bool
+	Host           Host
+	API            string
+	RuntimePath    string
+	RuntimeCLI     string
+	LoadAttributes bool
 
 	CPUPercentage float64
 	MemoryMaxKB   int64

--- a/host/host.go
+++ b/host/host.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/libp2p/go-libp2p"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	ma "github.com/multiformats/go-multiaddr"
@@ -20,6 +21,8 @@ type Host struct {
 
 	log zerolog.Logger
 	cfg Config
+
+	pubsub *pubsub.PubSub
 }
 
 // New creates a new Host.

--- a/host/subscribe.go
+++ b/host/subscribe.go
@@ -7,17 +7,23 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
-// Subscribe will have the host start listening to a specified gossipsub topic.
-func (h *Host) Subscribe(ctx context.Context, topic string) (*pubsub.Topic, *pubsub.Subscription, error) {
+func (h *Host) InitPubSub(ctx context.Context) error {
 
 	// Get a new PubSub object with the default router.
 	pubsub, err := pubsub.NewGossipSub(ctx, h)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not create new gossipsub: %w", err)
+		return fmt.Errorf("could not create new gossipsub: %w", err)
 	}
+	h.pubsub = pubsub
+
+	return nil
+}
+
+// Subscribe will have the host start listening to a specified gossipsub topic.
+func (h *Host) Subscribe(topic string) (*pubsub.Topic, *pubsub.Subscription, error) {
 
 	// Join the specified topic.
-	th, err := pubsub.Join(topic)
+	th, err := h.pubsub.Join(topic)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not join topic: %w", err)
 	}

--- a/host/subscribe.go
+++ b/host/subscribe.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -19,11 +20,26 @@ func (h *Host) InitPubSub(ctx context.Context) error {
 	return nil
 }
 
+func (h *Host) JoinTopic(topic string) (*pubsub.Topic, error) {
+
+	if h.pubsub == nil {
+		return nil, errors.New("pubsub is not initialized")
+	}
+
+	// Join the specified topic.
+	th, err := h.pubsub.Join(topic)
+	if err != nil {
+		return nil, fmt.Errorf("could not join topic: %w", err)
+	}
+
+	return th, nil
+}
+
 // Subscribe will have the host start listening to a specified gossipsub topic.
 func (h *Host) Subscribe(topic string) (*pubsub.Topic, *pubsub.Subscription, error) {
 
 	// Join the specified topic.
-	th, err := h.pubsub.Join(topic)
+	th, err := h.JoinTopic(topic)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not join topic: %w", err)
 	}

--- a/node/config.go
+++ b/node/config.go
@@ -15,7 +15,7 @@ type Option func(*Config)
 // DefaultConfig represents the default settings for the node.
 var DefaultConfig = Config{
 	Role:                    blockless.WorkerNode,
-	Topic:                   DefaultTopic,
+	Topics:                  []string{DefaultTopic},
 	HealthInterval:          DefaultHealthInterval,
 	RollCallTimeout:         DefaultRollCallTimeout,
 	Concurrency:             DefaultConcurrency,
@@ -28,7 +28,7 @@ var DefaultConfig = Config{
 // Config represents the Node configuration.
 type Config struct {
 	Role                    blockless.NodeRole // Node role.
-	Topic                   string             // Topic to subscribe to.
+	Topics                  []string           // Topics to subscribe to.
 	Execute                 blockless.Executor // Executor to use for running functions.
 	HealthInterval          time.Duration      // How often should we emit the health ping.
 	RollCallTimeout         time.Duration      // How long do we wait for roll call responses.
@@ -47,8 +47,8 @@ func (n *Node) ValidateConfig() error {
 		return errors.New("node role is not valid")
 	}
 
-	if n.cfg.Topic == "" {
-		return errors.New("topic cannot be empty")
+	if len(n.cfg.Topics) == 0 {
+		return errors.New("topics cannot be empty")
 	}
 
 	// Worker specific validation.
@@ -83,10 +83,10 @@ func WithRole(role blockless.NodeRole) Option {
 	}
 }
 
-// WithTopic specifies the p2p topic to which node should subscribe.
-func WithTopic(topic string) Option {
+// WithTopics specifies the p2p topics to which node should subscribe.
+func WithTopics(topics []string) Option {
 	return func(cfg *Config) {
-		cfg.Topic = topic
+		cfg.Topics = topics
 	}
 }
 

--- a/node/config_internal_test.go
+++ b/node/config_internal_test.go
@@ -24,14 +24,14 @@ func TestConfig_NodeRole(t *testing.T) {
 
 func TestConfig_Topic(t *testing.T) {
 
-	const topic = "super-secret-topic"
+	topics := []string{"super-secret-topic"}
 
 	cfg := Config{
-		Topic: "",
+		Topics: []string{},
 	}
 
-	WithTopic(topic)(&cfg)
-	require.Equal(t, topic, cfg.Topic)
+	WithTopics(topics)(&cfg)
+	require.Equal(t, topics, cfg.Topics)
 }
 
 func TestConfig_Executor(t *testing.T) {

--- a/node/execute_internal_test.go
+++ b/node/execute_internal_test.go
@@ -277,7 +277,7 @@ func TestNode_HeadExecute(t *testing.T) {
 		node := createNode(t, blockless.HeadNode)
 
 		ctx := context.Background()
-		_, err := node.subscribe(ctx)
+		err := node.subscribeToTopics(ctx)
 		require.NoError(t, err)
 
 		// Create a host that will receive the execution response.
@@ -331,7 +331,7 @@ func TestNode_HeadExecute(t *testing.T) {
 		node.listenDirectMessages(ctx)
 
 		defer cancel()
-		_, err := node.subscribe(ctx)
+		err := node.subscribeToTopics(ctx)
 		require.NoError(t, err)
 
 		// Create a host that will simulate a worker.
@@ -340,7 +340,10 @@ func TestNode_HeadExecute(t *testing.T) {
 		mockWorker, err := host.New(mocks.NoopLogger, loopback, 0)
 		require.NoError(t, err)
 
-		_, subscription, err := mockWorker.Subscribe(ctx, topic)
+		err = mockWorker.InitPubSub(ctx)
+		require.NoError(t, err)
+
+		_, subscription, err := mockWorker.Subscribe(topic)
 		require.NoError(t, err)
 
 		hostAddNewPeer(t, node.host, mockWorker)

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -17,7 +17,7 @@ import (
 	"github.com/blocklessnetwork/b7s/models/response"
 )
 
-// TODO: Check - head node really accepts execution requests from the REST API. Should this message handling be cognizant of `topics`?
+// NOTE: head node typically receives execution requests from the REST API. This message handling is not cognizant of subgroups.
 func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []byte) error {
 
 	// Unpack the request.

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -67,11 +67,7 @@ func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []b
 
 // headExecute is called on the head node. The head node will publish a roll call and delegate an execution request to chosen nodes.
 // The returned map contains execution results, mapped to the peer IDs of peers who reported them.
-func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Request, topic string) (codes.Code, execute.ResultMap, execute.Cluster, error) {
-
-	if topic == "" {
-		topic = DefaultTopic
-	}
+func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Request, subgroup string) (codes.Code, execute.ResultMap, execute.Cluster, error) {
 
 	nodeCount := 1
 	if req.Config.NodeCount > 1 {
@@ -94,7 +90,7 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 	log.Info().Msg("processing execution request")
 
 	// Phase 1. - Issue roll call to nodes.
-	reportingPeers, err := n.executeRollCall(ctx, requestID, req.FunctionID, nodeCount, consensusAlgo, topic, req.Config.Attributes)
+	reportingPeers, err := n.executeRollCall(ctx, requestID, req.FunctionID, nodeCount, consensusAlgo, subgroup, req.Config.Attributes)
 	if err != nil {
 		code := codes.Error
 		if errors.Is(err, blockless.ErrRollCallTimeout) {

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -17,6 +17,7 @@ import (
 	"github.com/blocklessnetwork/b7s/models/response"
 )
 
+// TODO: Check - head node really accepts execution requests from the REST API. Should this message handling be cognizant of `topics`?
 func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []byte) error {
 
 	// Unpack the request.
@@ -34,7 +35,7 @@ func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []b
 
 	log := n.log.With().Str("request", req.RequestID).Str("peer", from.String()).Str("function", req.FunctionID).Logger()
 
-	code, results, cluster, err := n.headExecute(ctx, requestID, req.Request)
+	code, results, cluster, err := n.headExecute(ctx, requestID, req.Request, "")
 	if err != nil {
 		log.Error().Err(err).Msg("execution failed")
 	}
@@ -66,7 +67,11 @@ func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []b
 
 // headExecute is called on the head node. The head node will publish a roll call and delegate an execution request to chosen nodes.
 // The returned map contains execution results, mapped to the peer IDs of peers who reported them.
-func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Request) (codes.Code, execute.ResultMap, execute.Cluster, error) {
+func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Request, topic string) (codes.Code, execute.ResultMap, execute.Cluster, error) {
+
+	if topic == "" {
+		topic = DefaultTopic
+	}
 
 	nodeCount := 1
 	if req.Config.NodeCount > 1 {
@@ -89,7 +94,7 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 	log.Info().Msg("processing execution request")
 
 	// Phase 1. - Issue roll call to nodes.
-	reportingPeers, err := n.executeRollCall(ctx, requestID, req.FunctionID, nodeCount, consensusAlgo, req.Config.Attributes)
+	reportingPeers, err := n.executeRollCall(ctx, requestID, req.FunctionID, nodeCount, consensusAlgo, topic, req.Config.Attributes)
 	if err != nil {
 		code := codes.Error
 		if errors.Is(err, blockless.ErrRollCallTimeout) {

--- a/node/health_internal_test.go
+++ b/node/health_internal_test.go
@@ -37,7 +37,7 @@ func TestNode_Health(t *testing.T) {
 	nhost, err := host.New(logger, loopback, 0)
 	require.NoError(t, err)
 
-	node, err := New(logger, nhost, peerstore, functionHandler, WithRole(blockless.HeadNode), WithHealthInterval(healthInterval), WithTopic(topic))
+	node, err := New(logger, nhost, peerstore, functionHandler, WithRole(blockless.HeadNode), WithHealthInterval(healthInterval), WithTopics([]string{topic}))
 	require.NoError(t, err)
 
 	// Create a host that will listen on the the topic to verify health pings
@@ -55,11 +55,14 @@ func TestNode_Health(t *testing.T) {
 	err = node.host.Connect(ctx, *info)
 	require.NoError(t, err)
 
-	// Have both client and node subscribe to the same topic.
-	_, subscription, err := receiver.Subscribe(ctx, topic)
+	err = receiver.InitPubSub(ctx)
 	require.NoError(t, err)
 
-	_, err = node.subscribe(ctx)
+	// Have both client and node subscribe to the same topic.
+	_, subscription, err := receiver.Subscribe(topic)
+	require.NoError(t, err)
+
+	err = node.subscribeToTopics(ctx)
 	require.NoError(t, err)
 
 	go node.HealthPing(ctx)

--- a/node/message.go
+++ b/node/message.go
@@ -16,10 +16,15 @@ type topicInfo struct {
 
 func (n *Node) subscribeToTopics(ctx context.Context) error {
 
+	err := n.host.InitPubSub(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize pubsub: %w", err)
+	}
+
 	// TODO: If some topics/subscriptions failed, cleanup those already subscribed to.
 	for _, topicName := range n.cfg.Topics {
 
-		topic, subscription, err := n.host.Subscribe(ctx, topicName)
+		topic, subscription, err := n.host.Subscribe(topicName)
 		if err != nil {
 			return fmt.Errorf("could not subscribe to topic (name: %s): %w", topicName, err)
 		}

--- a/node/message.go
+++ b/node/message.go
@@ -21,6 +21,8 @@ func (n *Node) subscribeToTopics(ctx context.Context) error {
 		return fmt.Errorf("could not initialize pubsub: %w", err)
 	}
 
+	n.log.Info().Strs("topics", n.cfg.Topics).Msg("topics node will subscribe to")
+
 	// TODO: If some topics/subscriptions failed, cleanup those already subscribed to.
 	for _, topicName := range n.cfg.Topics {
 

--- a/node/message_internal_test.go
+++ b/node/message_internal_test.go
@@ -64,16 +64,19 @@ func TestNode_Messaging(t *testing.T) {
 
 		ctx := context.Background()
 
+		err = client.InitPubSub(ctx)
+		require.NoError(t, err)
+
 		// Establish a connection between peers.
 		clientInfo := hostGetAddrInfo(t, client)
-		err := node.host.Connect(ctx, *clientInfo)
+		err = node.host.Connect(ctx, *clientInfo)
 		require.NoError(t, err)
 
 		// Have both client and node subscribe to the same topic.
-		_, subscription, err := client.Subscribe(ctx, topic)
+		_, subscription, err := client.Subscribe(topic)
 		require.NoError(t, err)
 
-		_, err = node.subscribe(ctx)
+		err = node.subscribeToTopics(ctx)
 		require.NoError(t, err)
 
 		time.Sleep(subscriptionDiseminationPause)

--- a/node/node.go
+++ b/node/node.go
@@ -32,7 +32,6 @@ type Node struct {
 	fstore   FStore
 
 	topics     map[string]*topicInfo
-	sema       chan struct{}
 	wg         *sync.WaitGroup
 	attributes *attributes.Attestation
 
@@ -71,8 +70,7 @@ func New(log zerolog.Logger, host *host.Host, peerStore PeerStore, fstore FStore
 		fstore:   fstore,
 		executor: cfg.Execute,
 
-		wg:   &sync.WaitGroup{},
-		sema: make(chan struct{}, cfg.Concurrency),
+		wg: &sync.WaitGroup{},
 
 		topics:             make(map[string]*topicInfo),
 		rollCall:           newQueue(rollCallQueueBufferSize),

--- a/node/node.go
+++ b/node/node.go
@@ -31,8 +31,9 @@ type Node struct {
 	executor blockless.Executor
 	fstore   FStore
 
-	subgroups  workSubgroups
+	sema       chan struct{}
 	wg         *sync.WaitGroup
+	subgroups  workSubgroups
 	attributes *attributes.Attestation
 
 	rollCall *rollCallQueue
@@ -76,6 +77,7 @@ func New(log zerolog.Logger, host *host.Host, peerStore PeerStore, fstore FStore
 		executor: cfg.Execute,
 
 		wg:        &sync.WaitGroup{},
+		sema:      make(chan struct{}, cfg.Concurrency),
 		subgroups: subgroups,
 
 		rollCall:           newQueue(rollCallQueueBufferSize),

--- a/node/node.go
+++ b/node/node.go
@@ -31,7 +31,7 @@ type Node struct {
 	executor blockless.Executor
 	fstore   FStore
 
-	topics     map[string]*topicInfo
+	subgroups  workSubgroups
 	wg         *sync.WaitGroup
 	attributes *attributes.Attestation
 
@@ -62,6 +62,11 @@ func New(log zerolog.Logger, host *host.Host, peerStore PeerStore, fstore FStore
 		cfg.Topics = append(cfg.Topics, DefaultTopic)
 	}
 
+	subgroups := workSubgroups{
+		RWMutex: &sync.RWMutex{},
+		topics:  make(map[string]*topicInfo),
+	}
+
 	n := &Node{
 		cfg: cfg,
 
@@ -70,9 +75,9 @@ func New(log zerolog.Logger, host *host.Host, peerStore PeerStore, fstore FStore
 		fstore:   fstore,
 		executor: cfg.Execute,
 
-		wg: &sync.WaitGroup{},
+		wg:        &sync.WaitGroup{},
+		subgroups: subgroups,
 
-		topics:             make(map[string]*topicInfo),
 		rollCall:           newQueue(rollCallQueueBufferSize),
 		clusters:           make(map[string]consensusExecutor),
 		executeResponses:   waitmap.New(),

--- a/node/rest.go
+++ b/node/rest.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ExecuteFunction can be used to start function execution. At the moment this is used by the API server to start execution on the head node.
-func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request, topic string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
+func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request, subgroup string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
 
 	if !n.isHead() {
 		return codes.NotAvailable, "", nil, execute.Cluster{}, fmt.Errorf("action not supported on this node type")
@@ -23,7 +23,7 @@ func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request, topic s
 		return codes.Error, "", nil, execute.Cluster{}, fmt.Errorf("could not generate request ID: %w", err)
 	}
 
-	code, results, cluster, err := n.headExecute(ctx, requestID, req, topic)
+	code, results, cluster, err := n.headExecute(ctx, requestID, req, subgroup)
 	if err != nil {
 		n.log.Error().Str("request", requestID).Err(err).Msg("execution failed")
 	}

--- a/node/rest.go
+++ b/node/rest.go
@@ -38,7 +38,7 @@ func (n *Node) ExecutionResult(id string) (execute.Result, bool) {
 }
 
 // PublishFunctionInstall publishes a function install message.
-func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid string, topic string) error {
+func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid string, subgroup string) error {
 
 	var req request.InstallFunction
 	if uri != "" {
@@ -51,13 +51,13 @@ func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid strin
 		req = createInstallMessageFromCID(cid)
 	}
 
-	if topic == "" {
-		topic = DefaultTopic
+	if subgroup == "" {
+		subgroup = DefaultTopic
 	}
 
-	n.log.Debug().Str("topic", topic).Str("url", req.ManifestURL).Str("cid", req.CID).Msg("publishing function install message")
+	n.log.Debug().Str("subgroup", subgroup).Str("url", req.ManifestURL).Str("cid", req.CID).Msg("publishing function install message")
 
-	err := n.publishToTopic(ctx, topic, req)
+	err := n.publishToTopic(ctx, subgroup, req)
 	if err != nil {
 		return fmt.Errorf("could not publish message: %w", err)
 	}

--- a/node/rest.go
+++ b/node/rest.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ExecuteFunction can be used to start function execution. At the moment this is used by the API server to start execution on the head node.
-func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
+func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request, topic string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
 
 	if !n.isHead() {
 		return codes.NotAvailable, "", nil, execute.Cluster{}, fmt.Errorf("action not supported on this node type")
@@ -23,7 +23,7 @@ func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request) (codes.
 		return codes.Error, "", nil, execute.Cluster{}, fmt.Errorf("could not generate request ID: %w", err)
 	}
 
-	code, results, cluster, err := n.headExecute(ctx, requestID, req)
+	code, results, cluster, err := n.headExecute(ctx, requestID, req, topic)
 	if err != nil {
 		n.log.Error().Str("request", requestID).Err(err).Msg("execution failed")
 	}
@@ -38,7 +38,7 @@ func (n *Node) ExecutionResult(id string) (execute.Result, bool) {
 }
 
 // PublishFunctionInstall publishes a function install message.
-func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid string) error {
+func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid string, topic string) error {
 
 	var req request.InstallFunction
 	if uri != "" {
@@ -51,9 +51,13 @@ func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid strin
 		req = createInstallMessageFromCID(cid)
 	}
 
-	n.log.Debug().Str("url", req.ManifestURL).Str("cid", req.CID).Msg("publishing function install message")
+	if topic == "" {
+		topic = DefaultTopic
+	}
 
-	err := n.publish(ctx, req)
+	n.log.Debug().Str("topic", topic).Str("url", req.ManifestURL).Str("cid", req.CID).Msg("publishing function install message")
+
+	err := n.publishToTopic(ctx, topic, req)
 	if err != nil {
 		return fmt.Errorf("could not publish message: %w", err)
 	}

--- a/node/rest_internal_test.go
+++ b/node/rest_internal_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNode_RestExecuteNotSupportedOnWorker(t *testing.T) {
 	node := createNode(t, blockless.WorkerNode)
-	_, _, _, _, err := node.ExecuteFunction(context.Background(), mocks.GenericExecutionRequest)
+	_, _, _, _, err := node.ExecuteFunction(context.Background(), mocks.GenericExecutionRequest, "")
 	require.Error(t, err)
 }
 

--- a/node/roll_call.go
+++ b/node/roll_call.go
@@ -102,7 +102,15 @@ func (n *Node) processRollCall(ctx context.Context, from peer.ID, payload []byte
 	return nil
 }
 
-func (n *Node) executeRollCall(ctx context.Context, requestID string, functionID string, nodeCount int, consensus consensus.Type, attributes *execute.Attributes) ([]peer.ID, error) {
+func (n *Node) executeRollCall(
+	ctx context.Context,
+	requestID string,
+	functionID string,
+	nodeCount int,
+	consensus consensus.Type,
+	topic string,
+	attributes *execute.Attributes,
+) ([]peer.ID, error) {
 
 	// Create a logger with relevant context.
 	log := n.log.With().Str("request", requestID).Str("function", functionID).Int("node_count", nodeCount).Logger()
@@ -112,7 +120,7 @@ func (n *Node) executeRollCall(ctx context.Context, requestID string, functionID
 	n.rollCall.create(requestID)
 	defer n.rollCall.remove(requestID)
 
-	err := n.publishRollCall(ctx, requestID, functionID, consensus, attributes)
+	err := n.publishRollCall(ctx, requestID, functionID, consensus, topic, attributes)
 	if err != nil {
 		return nil, fmt.Errorf("could not publish roll call: %w", err)
 	}
@@ -165,7 +173,7 @@ rollCallResponseLoop:
 
 // publishRollCall will create a roll call request for executing the given function.
 // On successful issuance of the roll call request, we return the ID of the issued request.
-func (n *Node) publishRollCall(ctx context.Context, requestID string, functionID string, consensus consensus.Type, attributes *execute.Attributes) error {
+func (n *Node) publishRollCall(ctx context.Context, requestID string, functionID string, consensus consensus.Type, topic string, attributes *execute.Attributes) error {
 
 	// Create a roll call request.
 	rollCall := request.RollCall{
@@ -178,7 +186,7 @@ func (n *Node) publishRollCall(ctx context.Context, requestID string, functionID
 	}
 
 	// Publish the mssage.
-	err := n.publish(ctx, rollCall)
+	err := n.publishToTopic(ctx, topic, rollCall)
 	if err != nil {
 		return fmt.Errorf("could not publish to topic: %w", err)
 	}

--- a/node/roll_call.go
+++ b/node/roll_call.go
@@ -113,7 +113,7 @@ func (n *Node) executeRollCall(
 ) ([]peer.ID, error) {
 
 	// Create a logger with relevant context.
-	log := n.log.With().Str("request", requestID).Str("function", functionID).Int("node_count", nodeCount).Logger()
+	log := n.log.With().Str("request", requestID).Str("function", functionID).Int("node_count", nodeCount).Str("topic", topic).Logger()
 
 	log.Info().Msg("performing roll call for request")
 

--- a/node/roll_call.go
+++ b/node/roll_call.go
@@ -185,6 +185,10 @@ func (n *Node) publishRollCall(ctx context.Context, requestID string, functionID
 		Attributes: attributes,
 	}
 
+	if topic == "" {
+		topic = DefaultTopic
+	}
+
 	// Publish the mssage.
 	err := n.publishToTopic(ctx, topic, rollCall)
 	if err != nil {

--- a/node/roll_call_internal_test.go
+++ b/node/roll_call_internal_test.go
@@ -245,6 +245,9 @@ func TestNode_RollCall(t *testing.T) {
 		receiver, err := host.New(mocks.NoopLogger, loopback, 0)
 		require.NoError(t, err)
 
+		err = receiver.InitPubSub(ctx)
+		require.NoError(t, err)
+
 		hostAddNewPeer(t, node.host, receiver)
 
 		info := hostGetAddrInfo(t, receiver)
@@ -252,10 +255,10 @@ func TestNode_RollCall(t *testing.T) {
 		require.NoError(t, err)
 
 		// Have both client and node subscribe to the same topic.
-		_, subscription, err := receiver.Subscribe(ctx, topic)
+		_, subscription, err := receiver.Subscribe(topic)
 		require.NoError(t, err)
 
-		_, err = node.subscribe(ctx)
+		err = node.subscribeToTopics(ctx)
 		require.NoError(t, err)
 
 		time.Sleep(subscriptionDiseminationPause)
@@ -263,7 +266,7 @@ func TestNode_RollCall(t *testing.T) {
 		requestID, err := newRequestID()
 		require.NoError(t, err)
 
-		err = node.publishRollCall(ctx, requestID, functionID, consensus.Type(0), nil)
+		err = node.publishRollCall(ctx, requestID, functionID, consensus.Type(0), "", nil)
 		require.NoError(t, err)
 
 		deadlineCtx, cancel := context.WithTimeout(ctx, publishTimeout)

--- a/node/subgroups.go
+++ b/node/subgroups.go
@@ -1,0 +1,36 @@
+package node
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Subgroups are (optional) groups of nodes that can work on specific things.
+// Generally all nodes subscribe to the B7S general topic and can receive work from there.
+// However, nodes can also be part of smaller groups, where they join a specific topic where
+// some specific work (roll calls) may be published to.
+type workSubgroups struct {
+	*sync.RWMutex
+	topics map[string]*topicInfo
+}
+
+// wrapper around topic joining + housekeeping.
+func (n *Node) joinTopic(topic string) (*topicInfo, error) {
+
+	n.subgroups.Lock()
+	defer n.subgroups.Unlock()
+
+	th, err := n.host.JoinTopic(topic)
+	if err != nil {
+		return nil, fmt.Errorf("could not join topic (topic: %s): %w", topic, err)
+	}
+
+	// NOTE: No subscription, joining topic only.
+	ti := &topicInfo{
+		handle: th,
+	}
+
+	n.subgroups.topics[topic] = ti
+
+	return ti, nil
+}

--- a/testing/mocks/node.go
+++ b/testing/mocks/node.go
@@ -10,16 +10,16 @@ import (
 
 // Node implements the `Node` interface expected by the API.
 type Node struct {
-	ExecuteFunctionFunc        func(context.Context, execute.Request) (codes.Code, string, execute.ResultMap, execute.Cluster, error)
+	ExecuteFunctionFunc        func(context.Context, execute.Request, string) (codes.Code, string, execute.ResultMap, execute.Cluster, error)
 	ExecutionResultFunc        func(id string) (execute.Result, bool)
-	PublishFunctionInstallFunc func(ctx context.Context, uri string, cid string) error
+	PublishFunctionInstallFunc func(ctx context.Context, uri string, cid string, subgroup string) error
 }
 
 func BaselineNode(t *testing.T) *Node {
 	t.Helper()
 
 	node := Node{
-		ExecuteFunctionFunc: func(context.Context, execute.Request) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
+		ExecuteFunctionFunc: func(context.Context, execute.Request, string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
 
 			results := execute.ResultMap{
 				GenericPeerID: GenericExecutionResult,
@@ -31,7 +31,7 @@ func BaselineNode(t *testing.T) *Node {
 		ExecutionResultFunc: func(id string) (execute.Result, bool) {
 			return GenericExecutionResult, true
 		},
-		PublishFunctionInstallFunc: func(ctx context.Context, uri string, cid string) error {
+		PublishFunctionInstallFunc: func(ctx context.Context, uri string, cid string, subgroup string) error {
 			return nil
 		},
 	}
@@ -39,14 +39,14 @@ func BaselineNode(t *testing.T) *Node {
 	return &node
 }
 
-func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
-	return n.ExecuteFunctionFunc(ctx, req)
+func (n *Node) ExecuteFunction(ctx context.Context, req execute.Request, subgroup string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
+	return n.ExecuteFunctionFunc(ctx, req, subgroup)
 }
 
 func (n *Node) ExecutionResult(id string) (execute.Result, bool) {
 	return n.ExecutionResultFunc(id)
 }
 
-func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid string) error {
-	return n.PublishFunctionInstallFunc(ctx, uri, cid)
+func (n *Node) PublishFunctionInstall(ctx context.Context, uri string, cid string, subgroup string) error {
+	return n.PublishFunctionInstallFunc(ctx, uri, cid, subgroup)
 }


### PR DESCRIPTION
This PR adds support for multiple work subgroups.

Subgroups are formed by introducing multiple pubsub topics to which work (roll calls) are published to. Changes are backwards compatible - if no explicit configuration is done, everything should work like before, and all nodes use the default topic as before (`blockless/b7s/general`). 

Operators can instruct their work nodes to make themselves available to specific topics of work by using CLI parameters, e.g. `node --topic blockless/b7s/topic1 --topic blockless/b7s/topic3`. Note that worker can include a list of topics. The default topic is always included as it's used to transmit some general data like health pings.

To direct work to a subgroup, HTTP requests to the head node execution endpoint (`/api/v1/functions/execute`) should include the `subgroup` field, e.g.

```json
{
    "subgroup": "blockless/b7s/topic1",
    "function_id": "{{hello-world-cid}}",
    "method": "{{hello-world-wasm}}",
    "config": {
        "number_of_nodes": 2,
        "result_aggregation": {
            "enable": false,
            "type": "none",
            "parameters": [
                {
                    "name": "type",
                    "value": ""
                }
            ]
        }
    }
}
```

If the subgroup is not specified, it's published to the general topic, which all worker nodes belong to.

Worker nodes have to have their topics specified on boot, and they will subscribe to all of them. However, head nodes do not. If a head node sees a `subgroup` it has not seen before, it will try to join that topic and publish to it, even if it's new to it ([fanout messages](https://docs.libp2p.io/concepts/pubsub/overview/#fan-out)). This makes the head node more flexible and doesn't require it to know a lot in advance.

Function install messages can also be directed to a specific subgroup.

Since we now have multiple subscriptions for ingress messages, main node run loop has been somewhat tweaked (and can be cleaner, but will be in a later PR).