### PR TITLE
Change node handling of locations for persisting data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 cmd/node/node
+cmd/node/.b7s_*
+
 cmd/keygen/keygen
 cmd/keyforge/keyforge
 cmd/bootstrap-limiter/bootstrap-limiter

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/blocklessnetwork/b7s/config"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/node"
 )
 
@@ -11,6 +12,7 @@ import (
 const (
 	defaultPort         = 0
 	defaultAddress      = "0.0.0.0"
+	defaultWorkspaceDir = "workspace"
 	defaultPeerDB       = "peer-db"
 	defaultFunctionDB   = "function-db"
 	defaultConcurrency  = uint(node.DefaultConcurrency)
@@ -27,13 +29,13 @@ func parseFlags() *config.Config {
 
 	// Node configuration.
 	pflag.StringVarP(&cfg.Role, "role", "r", defaultRole, "role this note will have in the Blockless protocol (head or worker)")
-	pflag.StringVar(&cfg.PeerDatabasePath, "peer-db", defaultPeerDB, "path to the database used for persisting peer data")
-	pflag.StringVar(&cfg.FunctionDatabasePath, "function-db", defaultFunctionDB, "path to the database used for persisting function data")
+	pflag.StringVar(&cfg.PeerDatabasePath, "peer-db", "", "path to the database used for persisting peer data")
+	pflag.StringVar(&cfg.FunctionDatabasePath, "function-db", "", "path to the database used for persisting function data")
 	pflag.UintVarP(&cfg.Concurrency, "concurrency", "c", defaultConcurrency, "maximum number of requests node will process in parallel")
 	pflag.StringVar(&cfg.API, "rest-api", "", "address where the head node REST API will listen on")
-	pflag.StringVar(&cfg.Workspace, "workspace", "./workspace", "directory that the node can use for file storage")
+	pflag.StringVar(&cfg.Workspace, "workspace", "", "directory that the node can use for file storage")
 	pflag.StringVar(&cfg.RuntimePath, "runtime-path", "", "runtime path (used by the worker node)")
-	pflag.StringVar(&cfg.RuntimeCLI, "runtime-cli", "", "runtime CLI name (used by the worker node)")
+	pflag.StringVar(&cfg.RuntimeCLI, "runtime-cli", blockless.RuntimeCLI(), "runtime CLI name (used by the worker node)")
 	pflag.BoolVar(&cfg.LoadAttributes, "attributes", false, "node should try to load its attribute data from IPFS")
 	pflag.StringSliceVar(&cfg.Topics, "topic", nil, "topics node should subscribe to")
 

--- a/cmd/node/id.go
+++ b/cmd/node/id.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func peerIDFromKey(keyPath string) (string, error) {
+
+	key, err := readPrivateKey(keyPath)
+	if err != nil {
+		log.Fatalf("could not read key file: %s", err)
+	}
+
+	id, err := peer.IDFromPrivateKey(key)
+	if err != nil {
+		log.Fatalf("could not determine identity: %s", err)
+	}
+
+	return id.String(), nil
+}
+
+func readPrivateKey(filepath string) (crypto.PrivKey, error) {
+
+	payload, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read file: %w", err)
+	}
+
+	key, err := crypto.UnmarshalPrivateKey(payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal private key: %w", err)
+	}
+
+	return key, nil
+}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -22,6 +23,10 @@ func New(log zerolog.Logger, options ...Option) (*Executor, error) {
 	cfg := defaultConfig
 	for _, option := range options {
 		option(&cfg)
+	}
+
+	if cfg.RuntimeDir == "" || cfg.ExecutableName == "" {
+		return nil, errors.New("runtime path and executable name are required")
 	}
 
 	// Convert the working directory to an absolute path too.

--- a/node/execution_results.go
+++ b/node/execution_results.go
@@ -126,7 +126,7 @@ func (n *Node) gatherExecutionResults(ctx context.Context, requestID string, pee
 				return
 			}
 
-			log.Info().Str("peer", rp.String()).Msg("accounted execution response from peer")
+			n.log.Info().Str("peer", rp.String()).Msg("accounted execution response from peer")
 
 			er := res.(response.Execute)
 


### PR DESCRIPTION
This PR changes the default locations where node persists files - the workspace, peer db and function db. Motivation for this is to ease the use of nodes when starting them directly. Before, if you'd start a head and worker node directly, you'd need to specify the paths directly else the nodes would trample each other's files (e.g. use `--peer-db worker-peerdb --function-db worker-function-db` ). 

Changes are not completely backwards compatible.

We differentiate three scenarios.

1. User specifies workspace, peer db or function db paths directly via CLI flags - in this case, we use those

2. User starts the node and specifies a private key.
In this case, it will store its files in `.b7s_<peer-id>` directory, in appropriate directories; for example:
	- .b7s_12D3KooWHUeKgXT4aj8oKvtwovVMki468igSsa5F8izZY3U5UyMD/workspace
	- .b7s_12D3KooWHUeKgXT4aj8oKvtwovVMki468igSsa5F8izZY3U5UyMD/peer-db
	- .b7s_12D3KooWHUeKgXT4aj8oKvtwovVMki468igSsa5F8izZY3U5UyMD/function-db

3. User starts the node without a private key
In this case, node has a random identity. IMO, this is mostly used for testing and transient stuff anyways, so it's somewhat expected that the DBs and workspace is transient too. In this case, a new temporary directory will be created where files will be stored, e.g. `/tmp/.b7s_2379210846`. 

I think these changes allow for more control over the node behavior and increase usability.

Also, fixed one bug that was introduced where we didn't detect if both `runtime-cli` and `runtime-path` CLI arguments were empty. Such a worker node would fail all executions and we should detect such an invalid configuration on boot.

WDYT?