### PR TITLE
Cleanup message handling code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 cmd/node/node
 cmd/node/.b7s_*
+cmd/node/*.yaml
 
 cmd/keygen/keygen
 cmd/keyforge/keyforge

--- a/api/health.go
+++ b/api/health.go
@@ -11,12 +11,8 @@ import (
 // Execute implements the REST API endpoint for function execution.
 func (a *API) Health(ctx echo.Context) error {
 
-	// respond with health check
-	resp := response.Health{
-		Type: "health",
-		Code: http.StatusOK,
-	}
-
-	// Send the response.
-	return ctx.JSON(http.StatusOK, resp)
+	return ctx.JSON(
+		http.StatusOK,
+		response.Health{Code: http.StatusOK},
+	)
 }

--- a/cmd/node/README.md
+++ b/cmd/node/README.md
@@ -69,12 +69,12 @@ log:
 connectivity:
   address: 127.0.0.1
   port: 9000
-  private-key: ~/.b7s/path/to/priv/key.bin
+  private-key: /home/user/.b7s/path/to/priv/key.bin
   websocket: true
 
 
 worker:
-  runtime-path: ~/.local/blockless-runtime/bin
+  runtime-path: /home/user/.local/blockless-runtime/bin
   cpu-percentage-limit: 0.8
 
 ```
@@ -101,7 +101,7 @@ The created `node` will listen on all addresses on TCP port 9000.
 Database used to persist Node data between runs will be created in the `peer-database` subdirectory.
 On the other hand, Node will persist function data in the default database, in the `function-db` subdirectory.
 
-Blockless Runtime path is given as `~/.local/bin`.
+Blockless Runtime path is given as `/home/user/.local/bin`.
 At startup, node will check if the Blockless Runtime is actually found there, namely the [bls-runtime](https://blockless.network/docs/protocol/runtime).
 
 Node Identity will be determined by the private key found in `priv.bin` file in the `keys` subdirectory.

--- a/cmd/node/internal/config/flags.go
+++ b/cmd/node/internal/config/flags.go
@@ -14,7 +14,7 @@ const (
 	DefaultFunctionDB   = "function-db"
 	DefaultConcurrency  = uint(node.DefaultConcurrency)
 	DefaultUseWebsocket = false
-	DefaultWorkspace    = ""
+	DefaultWorkspace    = "workspace"
 )
 
 type configOption struct {

--- a/cmd/node/internal/config/load.go
+++ b/cmd/node/internal/config/load.go
@@ -28,10 +28,10 @@ func load(args []string) (*Config, error) {
 	flags.stringFlag(roleCfg, DefaultRole)
 	flags.uintFlag(concurrencyCfg, DefaultConcurrency)
 	flags.stringSliceFlag(bootNodesCfg, nil)
-	flags.stringFlag(workspaceCfg, DefaultWorkspace)
+	flags.stringFlag(workspaceCfg, "")
 	flags.boolFlag(attributesCfg, false)
-	flags.stringFlag(peerDBCfg, DefaultPeerDB)
-	flags.stringFlag(functionDBCfg, DefaultFunctionDB)
+	flags.stringFlag(peerDBCfg, "")
+	flags.stringFlag(functionDBCfg, "")
 	flags.stringSliceFlag(topicsCfg, nil)
 
 	// Log.

--- a/consensus/pbft/execute.go
+++ b/consensus/pbft/execute.go
@@ -88,7 +88,6 @@ func (r *Replica) execute(view uint, sequence uint, digest string) error {
 	r.lastExecuted = sequence
 
 	msg := response.Execute{
-		Type:      blockless.MessageExecuteResponse,
 		Code:      res.Code,
 		RequestID: request.ID,
 		Results: execute.ResultMap{

--- a/models/blockless/message.go
+++ b/models/blockless/message.go
@@ -1,5 +1,7 @@
 package blockless
 
+// TODO: Remove unused/messages that don't make sense here.
+
 // Message types in the Blockless protocol.
 const (
 	MessageHealthCheck             = "MsgHealthCheck"
@@ -30,3 +32,7 @@ const (
 	MessageFormClusterResponse     = "MsgFormClusterResponse"
 	MessageDisbandCluster          = "MsgDisbandCluster"
 )
+
+type Message interface {
+	Type() string
+}

--- a/models/blockless/message.go
+++ b/models/blockless/message.go
@@ -1,33 +1,14 @@
 package blockless
 
-// TODO: Remove unused/messages that don't make sense here.
-
 // Message types in the Blockless protocol.
 const (
 	MessageHealthCheck             = "MsgHealthCheck"
-	MessageExecute                 = "MsgExecute"
-	MessageExecuteResult           = "MsgExecuteResult"
-	MessageExecuteError            = "MsgExecuteError"
-	MessageExecuteTimeout          = "MsgExecuteTimeout"
-	MessageExecuteUnknown          = "MsgExecuteUnknown"
-	MessageExecuteInvalid          = "MsgExecuteInvalid"
-	MessageExecuteNotFound         = "MsgExecuteNotFound"
-	MessageExecuteNotSupported     = "MsgExecuteNotSupported"
-	MessageExecuteNotImplemented   = "MsgExecuteNotImplemented"
-	MessageExecuteNotAuthorized    = "MsgExecuteNotAuthorized"
-	MessageExecuteNotPermitted     = "MsgExecuteNotPermitted"
-	MessageExecuteNotAvailable     = "MsgExecuteNotAvailable"
-	MessageExecuteNotReady         = "MsgExecuteNotReady"
-	MessageExecuteNotConnected     = "MsgExecuteNotConnected"
-	MessageExecuteNotInitialized   = "MsgExecuteNotInitialized"
-	MessageExecuteNotConfigured    = "MsgExecuteNotConfigured"
-	MessageExecuteNotInstalled     = "MsgExecuteNotInstalled"
-	MessageExecuteNotUpgraded      = "MsgExecuteNotUpgraded"
-	MessageRollCall                = "MsgRollCall"
-	MessageRollCallResponse        = "MsgRollCallResponse"
-	MessageExecuteResponse         = "MsgExecuteResponse"
 	MessageInstallFunction         = "MsgInstallFunction"
 	MessageInstallFunctionResponse = "MsgInstallFunctionResponse"
+	MessageRollCall                = "MsgRollCall"
+	MessageRollCallResponse        = "MsgRollCallResponse"
+	MessageExecute                 = "MsgExecute"
+	MessageExecuteResponse         = "MsgExecuteResponse"
 	MessageFormCluster             = "MsgFormCluster"
 	MessageFormClusterResponse     = "MsgFormClusterResponse"
 	MessageDisbandCluster          = "MsgDisbandCluster"

--- a/models/execute/request.go
+++ b/models/execute/request.go
@@ -19,7 +19,7 @@ type Parameter struct {
 
 // Config represents the configurable options for an execution request.
 type Config struct {
-	Runtime           BLSRuntimeConfig     `json:"runtime,omitempty"`
+	Runtime           BLSRuntimeConfig  `json:"runtime,omitempty"`
 	Environment       []EnvVar          `json:"env_vars,omitempty"`
 	Stdin             *string           `json:"stdin,omitempty"`
 	Permissions       []string          `json:"permissions,omitempty"`

--- a/models/request/disband_cluster.go
+++ b/models/request/disband_cluster.go
@@ -1,13 +1,32 @@
 package request
 
 import (
+	"encoding/json"
+
 	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
+
+var _ (json.Marshaler) = (*DisbandCluster)(nil)
 
 // DisbandCluster describes the `MessageDisbandCluster` request payload.
 // It is sent after head node receives the leaders execution response.
 type DisbandCluster struct {
-	Type      string  `json:"type,omitempty"`
 	From      peer.ID `json:"from,omitempty"`
 	RequestID string  `json:"request_id,omitempty"`
+}
+
+func (DisbandCluster) Type() string { return blockless.MessageDisbandCluster }
+
+func (d DisbandCluster) MarshalJSON() ([]byte, error) {
+	type Alias DisbandCluster
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(d),
+		Type:  d.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/models/request/disband_cluster.go
+++ b/models/request/disband_cluster.go
@@ -3,8 +3,6 @@ package request
 import (
 	"encoding/json"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
@@ -13,8 +11,7 @@ var _ (json.Marshaler) = (*DisbandCluster)(nil)
 // DisbandCluster describes the `MessageDisbandCluster` request payload.
 // It is sent after head node receives the leaders execution response.
 type DisbandCluster struct {
-	From      peer.ID `json:"from,omitempty"`
-	RequestID string  `json:"request_id,omitempty"`
+	RequestID string `json:"request_id,omitempty"`
 }
 
 func (DisbandCluster) Type() string { return blockless.MessageDisbandCluster }

--- a/models/request/execute.go
+++ b/models/request/execute.go
@@ -1,20 +1,23 @@
 package request
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
+var _ (json.Marshaler) = (*Execute)(nil)
+
 // Execute describes the `MessageExecute` request payload.
 type Execute struct {
-	Type string  `json:"type,omitempty"`
-	From peer.ID `json:"from,omitempty"`
-	Code string  `json:"code,omitempty"`
-	Topic string `json:"topic,omitempty"`
-	
+	From  peer.ID `json:"from,omitempty"`
+	Code  string  `json:"code,omitempty"`
+	Topic string  `json:"topic,omitempty"`
+
 	execute.Request // execute request is embedded.
 
 	// RequestID may be set initially, if the execution request is relayed via roll-call.
@@ -22,4 +25,18 @@ type Execute struct {
 
 	// Execution request timestamp is a factor for PBFT.
 	Timestamp time.Time `json:"timestamp,omitempty"`
+}
+
+func (Execute) Type() string { return blockless.MessageExecute }
+
+func (e Execute) MarshalJSON() ([]byte, error) {
+	type Alias Execute
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(e),
+		Type:  e.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/models/request/execute.go
+++ b/models/request/execute.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/execute"
 )
@@ -14,17 +12,11 @@ var _ (json.Marshaler) = (*Execute)(nil)
 
 // Execute describes the `MessageExecute` request payload.
 type Execute struct {
-	From  peer.ID `json:"from,omitempty"`
-	Code  string  `json:"code,omitempty"`
-	Topic string  `json:"topic,omitempty"`
-
 	execute.Request // execute request is embedded.
 
-	// RequestID may be set initially, if the execution request is relayed via roll-call.
-	RequestID string `json:"request_id,omitempty"`
-
-	// Execution request timestamp is a factor for PBFT.
-	Timestamp time.Time `json:"timestamp,omitempty"`
+	Topic     string    `json:"topic,omitempty"`
+	RequestID string    `json:"request_id,omitempty"` // RequestID may be set initially, if the execution request is relayed via roll-call.
+	Timestamp time.Time `json:"timestamp,omitempty"`  // Execution request timestamp is a factor for PBFT.
 }
 
 func (Execute) Type() string { return blockless.MessageExecute }

--- a/models/request/form_cluster.go
+++ b/models/request/form_cluster.go
@@ -1,17 +1,35 @@
 package request
 
 import (
+	"encoding/json"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/blocklessnetwork/b7s/consensus"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
+
+var _ (json.Marshaler) = (*FormCluster)(nil)
 
 // FormCluster describes the `MessageFormCluster` request payload.
 // It is sent on clustered execution of a request.
 type FormCluster struct {
-	Type      string         `json:"type,omitempty"`
 	From      peer.ID        `json:"from,omitempty"`
 	RequestID string         `json:"request_id,omitempty"`
 	Peers     []peer.ID      `json:"peers,omitempty"`
 	Consensus consensus.Type `json:"consensus,omitempty"`
+}
+
+func (FormCluster) Type() string { return blockless.MessageFormCluster }
+
+func (f FormCluster) MarshalJSON() ([]byte, error) {
+	type Alias FormCluster
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(f),
+		Type:  f.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/models/request/form_cluster.go
+++ b/models/request/form_cluster.go
@@ -14,7 +14,6 @@ var _ (json.Marshaler) = (*FormCluster)(nil)
 // FormCluster describes the `MessageFormCluster` request payload.
 // It is sent on clustered execution of a request.
 type FormCluster struct {
-	From      peer.ID        `json:"from,omitempty"`
 	RequestID string         `json:"request_id,omitempty"`
 	Peers     []peer.ID      `json:"peers,omitempty"`
 	Consensus consensus.Type `json:"consensus,omitempty"`

--- a/models/request/install_function.go
+++ b/models/request/install_function.go
@@ -1,13 +1,32 @@
 package request
 
 import (
+	"encoding/json"
+
 	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
+
+var _ (json.Marshaler) = (*InstallFunction)(nil)
 
 // InstallFunction describes the `MessageInstallFunction` request payload.
 type InstallFunction struct {
-	Type        string  `json:"type,omitempty"`
 	From        peer.ID `json:"from,omitempty"`
 	ManifestURL string  `json:"manifest_url,omitempty"`
 	CID         string  `json:"cid,omitempty"`
+}
+
+func (InstallFunction) Type() string { return blockless.MessageInstallFunction }
+
+func (f InstallFunction) MarshalJSON() ([]byte, error) {
+	type Alias InstallFunction
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(f),
+		Type:  f.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/models/request/install_function.go
+++ b/models/request/install_function.go
@@ -3,8 +3,6 @@ package request
 import (
 	"encoding/json"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
@@ -12,9 +10,8 @@ var _ (json.Marshaler) = (*InstallFunction)(nil)
 
 // InstallFunction describes the `MessageInstallFunction` request payload.
 type InstallFunction struct {
-	From        peer.ID `json:"from,omitempty"`
-	ManifestURL string  `json:"manifest_url,omitempty"`
-	CID         string  `json:"cid,omitempty"`
+	ManifestURL string `json:"manifest_url,omitempty"`
+	CID         string `json:"cid,omitempty"`
 }
 
 func (InstallFunction) Type() string { return blockless.MessageInstallFunction }

--- a/models/request/roll_call.go
+++ b/models/request/roll_call.go
@@ -1,19 +1,37 @@
 package request
 
 import (
+	"encoding/json"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/blocklessnetwork/b7s/consensus"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/execute"
 )
+
+var _ (json.Marshaler) = (*RollCall)(nil)
 
 // RollCall describes the `MessageRollCall` message payload.
 type RollCall struct {
 	From       peer.ID             `json:"from,omitempty"`
-	Type       string              `json:"type,omitempty"`
 	Origin     peer.ID             `json:"origin,omitempty"` // Origin is the peer that initiated the roll call.
 	FunctionID string              `json:"function_id,omitempty"`
 	RequestID  string              `json:"request_id,omitempty"`
 	Consensus  consensus.Type      `json:"consensus"`
 	Attributes *execute.Attributes `json:"attributes,omitempty"`
+}
+
+func (RollCall) Type() string { return blockless.MessageRollCall }
+
+func (r RollCall) MarshalJSON() ([]byte, error) {
+	type Alias RollCall
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(r),
+		Type:  r.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/models/request/roll_call.go
+++ b/models/request/roll_call.go
@@ -14,7 +14,6 @@ var _ (json.Marshaler) = (*RollCall)(nil)
 
 // RollCall describes the `MessageRollCall` message payload.
 type RollCall struct {
-	From       peer.ID             `json:"from,omitempty"`
 	Origin     peer.ID             `json:"origin,omitempty"` // Origin is the peer that initiated the roll call.
 	FunctionID string              `json:"function_id,omitempty"`
 	RequestID  string              `json:"request_id,omitempty"`

--- a/models/response/execute.go
+++ b/models/response/execute.go
@@ -10,13 +10,15 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
+var _ (json.Marshaler) = (*Execute)(nil)
+
 // Execute describes the response to the `MessageExecute` message.
 type Execute struct {
-	Type      string            `json:"type,omitempty"`
 	RequestID string            `json:"request_id,omitempty"`
 	From      peer.ID           `json:"from,omitempty"`
 	Code      codes.Code        `json:"code,omitempty"`
@@ -29,6 +31,20 @@ type Execute struct {
 
 	// Used to communicate the reason for failure to the user.
 	Message string `json:"message,omitempty"`
+}
+
+func (Execute) Type() string { return blockless.MessageExecuteResponse }
+
+func (e Execute) MarshalJSON() ([]byte, error) {
+	type Alias Execute
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(e),
+		Type:  e.Type(),
+	}
+	return json.Marshal(rec)
 }
 
 type PBFTResultInfo struct {

--- a/models/response/execute.go
+++ b/models/response/execute.go
@@ -20,7 +20,6 @@ var _ (json.Marshaler) = (*Execute)(nil)
 // Execute describes the response to the `MessageExecute` message.
 type Execute struct {
 	RequestID string            `json:"request_id,omitempty"`
-	From      peer.ID           `json:"from,omitempty"`
 	Code      codes.Code        `json:"code,omitempty"`
 	Results   execute.ResultMap `json:"results,omitempty"`
 	Cluster   execute.Cluster   `json:"cluster,omitempty"`
@@ -58,7 +57,6 @@ func (e *Execute) Sign(key crypto.PrivKey) error {
 	// Exclude signature and the `from` field from the signature.
 	cp := *e
 	cp.Signature = ""
-	cp.From = ""
 
 	payload, err := json.Marshal(cp)
 	if err != nil {
@@ -79,7 +77,6 @@ func (e Execute) VerifySignature(key crypto.PubKey) error {
 	// Exclude signature and the `from` field from the signature.
 	cp := e
 	cp.Signature = ""
-	cp.From = ""
 
 	payload, err := json.Marshal(cp)
 	if err != nil {

--- a/models/response/execute_test.go
+++ b/models/response/execute_test.go
@@ -15,7 +15,6 @@ func TestExecute_Signing(t *testing.T) {
 
 	sampleRes := Execute{
 		RequestID: mocks.GenericUUID.String(),
-		From:      mocks.GenericPeerID,
 		Code:      codes.OK,
 		Results: execute.ResultMap{
 			mocks.GenericPeerID: mocks.GenericExecutionResult,

--- a/models/response/execute_test.go
+++ b/models/response/execute_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 	"github.com/blocklessnetwork/b7s/models/execute"
 	"github.com/blocklessnetwork/b7s/testing/mocks"
@@ -15,7 +14,6 @@ import (
 func TestExecute_Signing(t *testing.T) {
 
 	sampleRes := Execute{
-		Type:      blockless.MessageExecuteResponse,
 		RequestID: mocks.GenericUUID.String(),
 		From:      mocks.GenericPeerID,
 		Code:      codes.OK,

--- a/models/response/form_cluster.go
+++ b/models/response/form_cluster.go
@@ -17,7 +17,7 @@ type FormCluster struct {
 	Consensus consensus.Type `json:"consensus,omitempty"`
 }
 
-func (FormCluster) Type() string { return blockless.MessageFormCluster }
+func (FormCluster) Type() string { return blockless.MessageFormClusterResponse }
 
 func (f FormCluster) MarshalJSON() ([]byte, error) {
 	type Alias FormCluster

--- a/models/response/form_cluster.go
+++ b/models/response/form_cluster.go
@@ -3,8 +3,6 @@ package response
 import (
 	"encoding/json"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/blocklessnetwork/b7s/consensus"
 	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
@@ -15,7 +13,6 @@ var _ (json.Marshaler) = (*FormCluster)(nil)
 // FormCluster describes the `MessageFormClusteRr` response.
 type FormCluster struct {
 	RequestID string         `json:"request_id,omitempty"`
-	From      peer.ID        `json:"from,omitempty"`
 	Code      codes.Code     `json:"code,omitempty"`
 	Consensus consensus.Type `json:"consensus,omitempty"`
 }

--- a/models/response/form_cluster.go
+++ b/models/response/form_cluster.go
@@ -1,17 +1,35 @@
 package response
 
 import (
+	"encoding/json"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/blocklessnetwork/b7s/consensus"
+	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 )
 
+var _ (json.Marshaler) = (*FormCluster)(nil)
+
 // FormCluster describes the `MessageFormClusteRr` response.
 type FormCluster struct {
-	Type      string         `json:"type,omitempty"`
 	RequestID string         `json:"request_id,omitempty"`
 	From      peer.ID        `json:"from,omitempty"`
 	Code      codes.Code     `json:"code,omitempty"`
 	Consensus consensus.Type `json:"consensus,omitempty"`
+}
+
+func (FormCluster) Type() string { return blockless.MessageFormCluster }
+
+func (f FormCluster) MarshalJSON() ([]byte, error) {
+	type Alias FormCluster
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(f),
+		Type:  f.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/models/response/health.go
+++ b/models/response/health.go
@@ -1,12 +1,30 @@
 package response
 
 import (
+	"encoding/json"
+
+	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+var _ (json.Marshaler) = (*Health)(nil)
+
 // Health describes the message sent as a health ping.
 type Health struct {
-	Type string  `json:"type,omitempty"`
 	From peer.ID `json:"from,omitempty"`
 	Code int     `json:"code,omitempty"`
+}
+
+func (Health) Type() string { return blockless.MessageHealthCheck }
+
+func (h Health) MarshalJSON() ([]byte, error) {
+	type Alias Health
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(h),
+		Type:  h.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/models/response/health.go
+++ b/models/response/health.go
@@ -4,15 +4,13 @@ import (
 	"encoding/json"
 
 	"github.com/blocklessnetwork/b7s/models/blockless"
-	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 var _ (json.Marshaler) = (*Health)(nil)
 
 // Health describes the message sent as a health ping.
 type Health struct {
-	From peer.ID `json:"from,omitempty"`
-	Code int     `json:"code,omitempty"`
+	Code int `json:"code,omitempty"`
 }
 
 func (Health) Type() string { return blockless.MessageHealthCheck }

--- a/models/response/install_function.go
+++ b/models/response/install_function.go
@@ -3,8 +3,6 @@ package response
 import (
 	"encoding/json"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 )
@@ -13,7 +11,6 @@ var _ (json.Marshaler) = (*InstallFunction)(nil)
 
 // InstallFunction describes the response to the `MessageInstallFunction` message.
 type InstallFunction struct {
-	From    peer.ID    `json:"from,omitempty"`
 	Code    codes.Code `json:"code,omitempty"`
 	Message string     `json:"message,omitempty"`
 	CID     string     `json:"cid,omitempty"`

--- a/models/response/install_function.go
+++ b/models/response/install_function.go
@@ -1,16 +1,34 @@
 package response
 
 import (
+	"encoding/json"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 )
 
+var _ (json.Marshaler) = (*InstallFunction)(nil)
+
 // InstallFunction describes the response to the `MessageInstallFunction` message.
 type InstallFunction struct {
-	Type    string     `json:"type,omitempty"`
 	From    peer.ID    `json:"from,omitempty"`
 	Code    codes.Code `json:"code,omitempty"`
 	Message string     `json:"message,omitempty"`
 	CID     string     `json:"cid,omitempty"`
+}
+
+func (InstallFunction) Type() string { return blockless.MessageInstallFunctionResponse }
+
+func (f InstallFunction) MarshalJSON() ([]byte, error) {
+	type Alias InstallFunction
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(f),
+		Type:  f.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/models/response/roll_call.go
+++ b/models/response/roll_call.go
@@ -3,8 +3,6 @@ package response
 import (
 	"encoding/json"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 )
@@ -13,9 +11,7 @@ var _ (json.Marshaler) = (*RollCall)(nil)
 
 // RollCall describes the `MessageRollCall` response payload.
 type RollCall struct {
-	From       peer.ID    `json:"from,omitempty"`
 	Code       codes.Code `json:"code,omitempty"`
-	Role       string     `json:"role,omitempty"`
 	FunctionID string     `json:"function_id,omitempty"`
 	RequestID  string     `json:"request_id,omitempty"`
 }

--- a/models/response/roll_call.go
+++ b/models/response/roll_call.go
@@ -1,17 +1,35 @@
 package response
 
 import (
+	"encoding/json"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 )
 
+var _ (json.Marshaler) = (*RollCall)(nil)
+
 // RollCall describes the `MessageRollCall` response payload.
 type RollCall struct {
-	Type       string     `json:"type,omitempty"`
 	From       peer.ID    `json:"from,omitempty"`
 	Code       codes.Code `json:"code,omitempty"`
 	Role       string     `json:"role,omitempty"`
 	FunctionID string     `json:"function_id,omitempty"`
 	RequestID  string     `json:"request_id,omitempty"`
+}
+
+func (RollCall) Type() string { return blockless.MessageRollCallResponse }
+
+func (r RollCall) MarshalJSON() ([]byte, error) {
+	type Alias RollCall
+	rec := struct {
+		Alias
+		Type string `json:"type"`
+	}{
+		Alias: Alias(r),
+		Type:  r.Type(),
+	}
+	return json.Marshal(rec)
 }

--- a/node/cluster.go
+++ b/node/cluster.go
@@ -97,7 +97,6 @@ func (n *Node) formCluster(ctx context.Context, requestID string, replicas []pee
 
 	// Create cluster formation request.
 	reqCluster := request.FormCluster{
-		Type:      blockless.MessageFormCluster,
 		RequestID: requestID,
 		Peers:     replicas,
 		Consensus: consensus,
@@ -162,7 +161,6 @@ func (n *Node) formCluster(ctx context.Context, requestID string, replicas []pee
 func (n *Node) disbandCluster(requestID string, replicas []peer.ID) error {
 
 	msgDisband := request.DisbandCluster{
-		Type:      blockless.MessageDisbandCluster,
 		RequestID: requestID,
 	}
 

--- a/node/cluster.go
+++ b/node/cluster.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -16,21 +15,13 @@ import (
 	"github.com/blocklessnetwork/b7s/models/response"
 )
 
-func (n *Node) processFormCluster(ctx context.Context, from peer.ID, payload []byte) error {
+func (n *Node) processFormCluster(ctx context.Context, from peer.ID, req request.FormCluster) error {
 
 	// Should never happen.
 	if !n.isWorker() {
 		n.log.Warn().Str("peer", from.String()).Msg("only worker nodes participate in consensus clusters")
 		return nil
 	}
-
-	// Unpack the request.
-	var req request.FormCluster
-	err := json.Unmarshal(payload, &req)
-	if err != nil {
-		return fmt.Errorf("could not unpack the request: %w", err)
-	}
-	req.From = from
 
 	n.log.Info().Str("request", req.RequestID).Strs("peers", blockless.PeerIDsToStr(req.Peers)).Str("consensus", req.Consensus.String()).Msg("received request to form consensus cluster")
 
@@ -46,15 +37,7 @@ func (n *Node) processFormCluster(ctx context.Context, from peer.ID, payload []b
 }
 
 // processFormClusterResponse will record the cluster formation response.
-func (n *Node) processFormClusterResponse(ctx context.Context, from peer.ID, payload []byte) error {
-
-	// Unpack the message.
-	var res response.FormCluster
-	err := json.Unmarshal(payload, &res)
-	if err != nil {
-		return fmt.Errorf("could not unpack the cluster formation response: %w", err)
-	}
-	res.From = from
+func (n *Node) processFormClusterResponse(ctx context.Context, from peer.ID, res response.FormCluster) error {
 
 	n.log.Debug().Str("request", res.RequestID).Str("from", from.String()).Msg("received cluster formation response")
 
@@ -65,7 +48,7 @@ func (n *Node) processFormClusterResponse(ctx context.Context, from peer.ID, pay
 }
 
 // processDisbandCluster will start cluster shutdown command.
-func (n *Node) processDisbandCluster(ctx context.Context, from peer.ID, payload []byte) error {
+func (n *Node) processDisbandCluster(ctx context.Context, from peer.ID, req request.DisbandCluster) error {
 
 	// Should never happen.
 	if !n.isWorker() {
@@ -73,17 +56,9 @@ func (n *Node) processDisbandCluster(ctx context.Context, from peer.ID, payload 
 		return nil
 	}
 
-	// Unpack the request.
-	var req request.DisbandCluster
-	err := json.Unmarshal(payload, &req)
-	if err != nil {
-		return fmt.Errorf("could not unpack the request: %w", err)
-	}
-	req.From = from
-
 	n.log.Info().Str("peer", from.String()).Str("request", req.RequestID).Msg("received request to disband consensus cluster")
 
-	err = n.leaveCluster(req.RequestID, consensusClusterDisbandTimeout)
+	err := n.leaveCluster(req.RequestID, consensusClusterDisbandTimeout)
 	if err != nil {
 		return fmt.Errorf("could not disband cluster (request: %s): %w", req.RequestID, err)
 	}

--- a/node/cluster_pbft_integration_test.go
+++ b/node/cluster_pbft_integration_test.go
@@ -175,7 +175,6 @@ This is the end of my program
 		var res response.InstallFunction
 		getStreamPayload(t, stream, &res)
 
-		require.Equal(t, blockless.MessageInstallFunctionResponse, res.Type)
 		require.Equal(t, codes.Accepted, res.Code)
 		require.Equal(t, "installed", res.Message)
 
@@ -210,7 +209,6 @@ This is the end of my program
 		var res response.Execute
 		getStreamPayload(t, stream, &res)
 
-		require.Equal(t, blockless.MessageExecuteResponse, res.Type)
 		require.Equal(t, codes.OK, res.Code)
 		require.NotEmpty(t, res.RequestID)
 

--- a/node/consensus.go
+++ b/node/consensus.go
@@ -11,7 +11,6 @@ import (
 	"github.com/blocklessnetwork/b7s/consensus"
 	"github.com/blocklessnetwork/b7s/consensus/pbft"
 	"github.com/blocklessnetwork/b7s/consensus/raft"
-	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 	"github.com/blocklessnetwork/b7s/models/execute"
 	"github.com/blocklessnetwork/b7s/models/request"
@@ -40,7 +39,6 @@ func (n *Node) createRaftCluster(ctx context.Context, from peer.ID, fc request.F
 		defer cancel()
 
 		msg := response.Execute{
-			Type:      blockless.MessageExecuteResponse,
 			Code:      res.Code,
 			RequestID: req.RequestID,
 			Results: execute.ResultMap{
@@ -72,7 +70,6 @@ func (n *Node) createRaftCluster(ctx context.Context, from peer.ID, fc request.F
 	n.clusterLock.Unlock()
 
 	res := response.FormCluster{
-		Type:      blockless.MessageFormClusterResponse,
 		RequestID: fc.RequestID,
 		Code:      codes.OK,
 		Consensus: fc.Consensus,
@@ -109,7 +106,6 @@ func (n *Node) createPBFTCluster(ctx context.Context, from peer.ID, fc request.F
 	n.clusterLock.Unlock()
 
 	res := response.FormCluster{
-		Type:      blockless.MessageFormClusterResponse,
 		RequestID: fc.RequestID,
 		Code:      codes.OK,
 		Consensus: fc.Consensus,

--- a/node/execute.go
+++ b/node/execute.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -11,26 +10,19 @@ import (
 	"github.com/blocklessnetwork/b7s/consensus"
 	"github.com/blocklessnetwork/b7s/models/codes"
 	"github.com/blocklessnetwork/b7s/models/execute"
+	"github.com/blocklessnetwork/b7s/models/request"
 	"github.com/blocklessnetwork/b7s/models/response"
 )
 
-func (n *Node) processExecute(ctx context.Context, from peer.ID, payload []byte) error {
+func (n *Node) processExecute(ctx context.Context, from peer.ID, req request.Execute) error {
 	// We execute functions differently depending on the node role.
 	if n.isHead() {
-		return n.headProcessExecute(ctx, from, payload)
+		return n.headProcessExecute(ctx, from, req)
 	}
-	return n.workerProcessExecute(ctx, from, payload)
+	return n.workerProcessExecute(ctx, from, req)
 }
 
-func (n *Node) processExecuteResponse(ctx context.Context, from peer.ID, payload []byte) error {
-
-	// Unpack the message.
-	var res response.Execute
-	err := json.Unmarshal(payload, &res)
-	if err != nil {
-		return fmt.Errorf("could not unpack execute response: %w", err)
-	}
-	res.From = from
+func (n *Node) processExecuteResponse(ctx context.Context, from peer.ID, res response.Execute) error {
 
 	n.log.Debug().Str("request", res.RequestID).Str("from", from.String()).Msg("received execution response")
 

--- a/node/execute_integration_test.go
+++ b/node/execute_integration_test.go
@@ -146,7 +146,6 @@ This is the end of my program
 		var res response.InstallFunction
 		getStreamPayload(t, stream, &res)
 
-		require.Equal(t, blockless.MessageInstallFunctionResponse, res.Type)
 		require.Equal(t, codes.Accepted, res.Code)
 		require.Equal(t, "installed", res.Message)
 
@@ -179,7 +178,6 @@ This is the end of my program
 		var res response.Execute
 		getStreamPayload(t, stream, &res)
 
-		require.Equal(t, blockless.MessageExecuteResponse, res.Type)
 		require.Equal(t, codes.OK, res.Code)
 		require.NotEmpty(t, res.RequestID)
 		require.Equal(t, expectedExecutionResult, res.Results[worker.host.ID()].Result.Stdout)

--- a/node/execute_internal_test.go
+++ b/node/execute_internal_test.go
@@ -29,7 +29,6 @@ func TestNode_WorkerExecute(t *testing.T) {
 	)
 
 	executionRequest := request.Execute{
-		Type:      blockless.MessageExecute,
 		RequestID: requestID,
 		Request: execute.Request{
 			FunctionID: functionID,
@@ -86,8 +85,6 @@ func TestNode_WorkerExecute(t *testing.T) {
 
 			var received response.Execute
 			getStreamPayload(t, stream, &received)
-
-			require.Equal(t, blockless.MessageExecuteResponse, received.Type)
 
 			// We should receive the response the baseline executor will return.
 			expected := mocks.GenericExecutionResult
@@ -151,7 +148,6 @@ func TestNode_WorkerExecute(t *testing.T) {
 			var received response.Execute
 			getStreamPayload(t, stream, &received)
 
-			require.Equal(t, blockless.MessageExecuteResponse, received.Type)
 			require.Equal(t, received.RequestID, requestID)
 			require.Equal(t, faultyExecutionResult.Code, received.Code)
 			require.Equal(t, faultyExecutionResult.Result, received.Results[node.host.ID()].Result)
@@ -193,8 +189,6 @@ func TestNode_WorkerExecute(t *testing.T) {
 			var received response.Execute
 			getStreamPayload(t, stream, &received)
 
-			require.Equal(t, blockless.MessageExecuteResponse, received.Type)
-
 			require.Equal(t, received.Code, codes.Error)
 		})
 
@@ -220,8 +214,6 @@ func TestNode_WorkerExecute(t *testing.T) {
 
 			var received response.Execute
 			getStreamPayload(t, stream, &received)
-
-			require.Equal(t, blockless.MessageExecuteResponse, received.Type)
 
 			require.Equal(t, codes.NotFound, received.Code)
 		})
@@ -260,7 +252,6 @@ func TestNode_HeadExecute(t *testing.T) {
 	)
 
 	executionRequest := request.Execute{
-		Type: blockless.MessageExecute,
 		Request: execute.Request{
 			FunctionID: functionID,
 			Method:     functionMethod,
@@ -299,7 +290,6 @@ func TestNode_HeadExecute(t *testing.T) {
 			var received response.Execute
 			getStreamPayload(t, stream, &received)
 
-			require.Equal(t, blockless.MessageExecuteResponse, received.Type)
 			require.Equal(t, codes.Timeout, received.Code)
 		})
 
@@ -362,10 +352,7 @@ func TestNode_HeadExecute(t *testing.T) {
 			from := stream.Conn().RemotePeer()
 			require.Equal(t, node.host.ID(), from)
 
-			require.Equal(t, blockless.MessageExecute, req.Type)
-
 			res := response.Execute{
-				Type:      blockless.MessageExecuteResponse,
 				Code:      codes.OK,
 				RequestID: requestID,
 				Results: map[peer.ID]execute.Result{
@@ -398,7 +385,6 @@ func TestNode_HeadExecute(t *testing.T) {
 
 			var res response.Execute
 			getStreamPayload(t, stream, &res)
-			require.Equal(t, blockless.MessageExecuteResponse, res.Type)
 
 			require.Equal(t, codes.OK, res.Code)
 			require.Equal(t, requestID, res.RequestID)
@@ -435,7 +421,6 @@ func TestNode_HeadExecute(t *testing.T) {
 		var received request.RollCall
 		err = json.Unmarshal(msg.Data, &received)
 
-		require.Equal(t, blockless.MessageRollCall, received.Type)
 		require.Equal(t, functionID, received.FunctionID)
 
 		requestID = received.RequestID
@@ -443,7 +428,6 @@ func TestNode_HeadExecute(t *testing.T) {
 
 		// Reply to the server that we can do the work.
 		res := response.RollCall{
-			Type:       blockless.MessageRollCallResponse,
 			Code:       codes.Accepted,
 			FunctionID: received.FunctionID,
 			RequestID:  requestID,

--- a/node/execute_internal_test.go
+++ b/node/execute_internal_test.go
@@ -38,8 +38,6 @@ func TestNode_WorkerExecute(t *testing.T) {
 		},
 	}
 
-	payload := serialize(t, executionRequest)
-
 	t.Run("handles correct execution", func(t *testing.T) {
 		t.Parallel()
 
@@ -94,7 +92,7 @@ func TestNode_WorkerExecute(t *testing.T) {
 			require.Equal(t, expected.Result, received.Results[node.host.ID()].Result)
 		})
 
-		err = node.processExecute(context.Background(), receiver.ID(), payload)
+		err = node.processExecute(context.Background(), receiver.ID(), executionRequest)
 		require.NoError(t, err)
 
 		wg.Wait()
@@ -153,7 +151,7 @@ func TestNode_WorkerExecute(t *testing.T) {
 			require.Equal(t, faultyExecutionResult.Result, received.Results[node.host.ID()].Result)
 		})
 
-		err = node.processExecute(context.Background(), receiver.ID(), payload)
+		err = node.processExecute(context.Background(), receiver.ID(), executionRequest)
 		require.NoError(t, err)
 
 		wg.Wait()
@@ -192,7 +190,7 @@ func TestNode_WorkerExecute(t *testing.T) {
 			require.Equal(t, received.Code, codes.Error)
 		})
 
-		err = node.processExecute(context.Background(), receiver.ID(), payload)
+		err = node.processExecute(context.Background(), receiver.ID(), executionRequest)
 		require.NoError(t, err)
 
 		wg.Wait()
@@ -218,27 +216,10 @@ func TestNode_WorkerExecute(t *testing.T) {
 			require.Equal(t, codes.NotFound, received.Code)
 		})
 
-		err = node.processExecute(context.Background(), receiver.ID(), payload)
+		err = node.processExecute(context.Background(), receiver.ID(), executionRequest)
 		require.NoError(t, err)
 
 		wg.Wait()
-	})
-	t.Run("handles malformed request", func(t *testing.T) {
-		t.Parallel()
-
-		const (
-			// JSON without closing brace.
-			malformedJSON = `{
-						"type": "MsgExecute",
-						"function_id": "dummy-function-id",
-						"method": "dummy-function-method",
-						"config": {}`
-		)
-
-		node := createNode(t, blockless.WorkerNode)
-
-		err := node.processExecute(context.Background(), mocks.GenericPeerID, []byte(malformedJSON))
-		require.Error(t, err)
 	})
 }
 
@@ -259,8 +240,6 @@ func TestNode_HeadExecute(t *testing.T) {
 			Config:     execute.Config{},
 		},
 	}
-
-	payload := serialize(t, executionRequest)
 
 	t.Run("handles roll call timeout", func(t *testing.T) {
 		t.Parallel()
@@ -294,7 +273,7 @@ func TestNode_HeadExecute(t *testing.T) {
 		})
 
 		// Since no one will respond to a roll call, this is bound to time out.
-		err = node.processExecute(ctx, receiver.ID(), payload)
+		err = node.processExecute(ctx, receiver.ID(), executionRequest)
 		require.NoError(t, err)
 
 		wg.Wait()
@@ -402,7 +381,7 @@ func TestNode_HeadExecute(t *testing.T) {
 
 			time.Sleep(subscriptionDiseminationPause)
 
-			err = node.processExecute(ctx, receiver.ID(), payload)
+			err = node.processExecute(ctx, receiver.ID(), executionRequest)
 			require.NoError(t, err)
 		}()
 

--- a/node/handlers.go
+++ b/node/handlers.go
@@ -46,7 +46,7 @@ func (n *Node) processRollCallResponse(ctx context.Context, from peer.ID, res re
 	return nil
 }
 
-func (n *Node) processInstallFunctionResponse(ctx context.Context, from peer.ID, _ response.InstallFunction) error {
-	n.log.Trace().Str("from", from.String()).Msg("function install response received")
+func (n *Node) processInstallFunctionResponse(ctx context.Context, from peer.ID, res response.InstallFunction) error {
+	n.log.Trace().Str("from", from.String()).Str("cid", res.CID).Msg("function install response received")
 	return nil
 }

--- a/node/handlers_internal_test.go
+++ b/node/handlers_internal_test.go
@@ -29,8 +29,7 @@ func TestNode_Handlers(t *testing.T) {
 			Code: http.StatusOK,
 		}
 
-		payload := serialize(t, msg)
-		err := node.processHealthCheck(context.Background(), mocks.GenericPeerID, payload)
+		err := node.processHealthCheck(context.Background(), mocks.GenericPeerID, msg)
 		require.NoError(t, err)
 	})
 	t.Run("roll call response", func(t *testing.T) {
@@ -44,14 +43,13 @@ func TestNode_Handlers(t *testing.T) {
 
 		res := response.RollCall{
 			Code:       codes.Accepted,
-			Role:       "dummy-role",
 			FunctionID: "dummy-function-id",
 			RequestID:  requestID,
 		}
 
 		// Record response asynchronously.
 		var wg sync.WaitGroup
-		var recordedResponse response.RollCall
+		var recordedResponse rollCallResponse
 		go func() {
 			defer wg.Done()
 			recordedResponse = <-node.rollCall.responses(requestID)
@@ -59,15 +57,13 @@ func TestNode_Handlers(t *testing.T) {
 
 		wg.Add(1)
 
-		payload := serialize(t, res)
-		err := node.processRollCallResponse(context.Background(), mocks.GenericPeerID, payload)
+		err := node.processRollCallResponse(context.Background(), mocks.GenericPeerID, res)
 		require.NoError(t, err)
 
 		wg.Wait()
 
 		expected := res
-		expected.From = mocks.GenericPeerID
-		require.Equal(t, expected, recordedResponse)
+		require.Equal(t, expected, recordedResponse.RollCall)
 	})
 	t.Run("skipping inadequate roll call responses", func(t *testing.T) {
 		t.Parallel()
@@ -82,12 +78,10 @@ func TestNode_Handlers(t *testing.T) {
 		res := response.RollCall{
 			Code:       codes.NotFound,
 			RequestID:  requestID,
-			Role:       "dummy-role",
 			FunctionID: "dummy-function-id",
 		}
 
-		payload := serialize(t, res)
-		err := node.processRollCallResponse(context.Background(), mocks.GenericPeerID, payload)
+		err := node.processRollCallResponse(context.Background(), mocks.GenericPeerID, res)
 		require.NoError(t, err)
 
 		// Verify roll call response is not found, even though the response has been processed.
@@ -109,8 +103,7 @@ func TestNode_Handlers(t *testing.T) {
 			Message: "dummy-message",
 		}
 
-		payload := serialize(t, msg)
-		err := node.processInstallFunctionResponse(context.Background(), mocks.GenericPeerID, payload)
+		err := node.processInstallFunctionResponse(context.Background(), mocks.GenericPeerID, msg)
 		require.NoError(t, err)
 	})
 }
@@ -127,14 +120,12 @@ func TestNode_InstallFunction(t *testing.T) {
 		CID:         cid,
 	}
 
-	payload := serialize(t, installReq)
-
 	t.Run("head node handles install", func(t *testing.T) {
 		t.Parallel()
 
 		node := createNode(t, blockless.HeadNode)
 
-		err := node.processInstallFunction(context.Background(), mocks.GenericPeerID, payload)
+		err := node.processInstallFunction(context.Background(), mocks.GenericPeerID, installReq)
 		require.NoError(t, err)
 	})
 	t.Run("worker node handles install", func(t *testing.T) {
@@ -167,7 +158,7 @@ func TestNode_InstallFunction(t *testing.T) {
 			require.Equal(t, expectedMessage, received.Message)
 		})
 
-		err = node.processInstallFunction(context.Background(), receiver.ID(), payload)
+		err = node.processInstallFunction(context.Background(), receiver.ID(), installReq)
 		require.NoError(t, err)
 
 		wg.Wait()
@@ -196,31 +187,7 @@ func TestNode_InstallFunction(t *testing.T) {
 			require.Fail(t, "unexpected response")
 		})
 
-		err = node.processInstallFunction(context.Background(), receiver.ID(), payload)
-		require.Error(t, err)
-	})
-	t.Run("worker node handles invalid function install requeset", func(t *testing.T) {
-		t.Parallel()
-
-		const (
-			// JSON without closing brace.
-			brokenPayload = `{
-				"type": "MsgInstallFunction",
-				"manifest_url": "https://example.com/manifest-url",
-				"cid": "dummy-cid"`
-		)
-
-		receiver, err := host.New(mocks.NoopLogger, loopback, 0)
-		require.NoError(t, err)
-
-		node := createNode(t, blockless.WorkerNode)
-		hostAddNewPeer(t, node.host, receiver)
-
-		receiver.SetStreamHandler(blockless.ProtocolID, func(stream network.Stream) {
-			require.Fail(t, "unexpected response")
-		})
-
-		err = node.processInstallFunction(context.Background(), receiver.ID(), []byte(brokenPayload))
+		err = node.processInstallFunction(context.Background(), receiver.ID(), installReq)
 		require.Error(t, err)
 	})
 	t.Run("worker node handles failure to send response", func(t *testing.T) {
@@ -233,7 +200,7 @@ func TestNode_InstallFunction(t *testing.T) {
 
 		node := createNode(t, blockless.WorkerNode)
 
-		err = node.processInstallFunction(context.Background(), receiver.ID(), payload)
+		err = node.processInstallFunction(context.Background(), receiver.ID(), installReq)
 		require.Error(t, err)
 	})
 }

--- a/node/handlers_internal_test.go
+++ b/node/handlers_internal_test.go
@@ -26,7 +26,6 @@ func TestNode_Handlers(t *testing.T) {
 		t.Parallel()
 
 		msg := response.Health{
-			Type: blockless.MessageHealthCheck,
 			Code: http.StatusOK,
 		}
 
@@ -44,7 +43,6 @@ func TestNode_Handlers(t *testing.T) {
 		node.rollCall.create(requestID)
 
 		res := response.RollCall{
-			Type:       blockless.MessageRollCallResponse,
 			Code:       codes.Accepted,
 			Role:       "dummy-role",
 			FunctionID: "dummy-function-id",
@@ -82,7 +80,6 @@ func TestNode_Handlers(t *testing.T) {
 
 		// We only want responses with the code `Accepted`.
 		res := response.RollCall{
-			Type:       blockless.MessageRollCallResponse,
 			Code:       codes.NotFound,
 			RequestID:  requestID,
 			Role:       "dummy-role",
@@ -108,7 +105,6 @@ func TestNode_Handlers(t *testing.T) {
 		t.Parallel()
 
 		msg := response.InstallFunction{
-			Type:    blockless.MessageInstallFunctionResponse,
 			Code:    codes.OK,
 			Message: "dummy-message",
 		}
@@ -167,7 +163,6 @@ func TestNode_InstallFunction(t *testing.T) {
 			var received response.InstallFunction
 			getStreamPayload(t, stream, &received)
 
-			require.Equal(t, blockless.MessageInstallFunctionResponse, received.Type)
 			require.Equal(t, codes.Accepted, received.Code)
 			require.Equal(t, expectedMessage, received.Message)
 		})

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -44,7 +44,6 @@ func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []b
 
 	// Create the execution response from the execution result.
 	res := response.Execute{
-		Type:      blockless.MessageExecuteResponse,
 		Code:      code,
 		RequestID: requestID,
 		Results:   results,
@@ -126,7 +125,6 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 
 	// Send the execution request to peers in the cluster. Non-leaders will drop the request.
 	reqExecute := request.Execute{
-		Type:      blockless.MessageExecute,
 		Request:   req,
 		RequestID: requestID,
 		Timestamp: time.Now().UTC(),

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -18,15 +17,7 @@ import (
 )
 
 // NOTE: head node typically receives execution requests from the REST API. This message handling is not cognizant of subgroups.
-func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []byte) error {
-
-	// Unpack the request.
-	var req request.Execute
-	err := json.Unmarshal(payload, &req)
-	if err != nil {
-		return fmt.Errorf("could not unpack the request: %w", err)
-	}
-	req.From = from
+func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, req request.Execute) error {
 
 	requestID, err := newRequestID()
 	if err != nil {
@@ -56,7 +47,7 @@ func (n *Node) headProcessExecute(ctx context.Context, from peer.ID, payload []b
 	}
 
 	// Send the response, whatever it may be (success or failure).
-	err = n.send(ctx, req.From, res)
+	err = n.send(ctx, from, res)
 	if err != nil {
 		return fmt.Errorf("could not send response: %w", err)
 	}

--- a/node/health.go
+++ b/node/health.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/response"
 )
 
@@ -20,7 +19,6 @@ func (n *Node) HealthPing(ctx context.Context) {
 		case <-ticker.C:
 
 			msg := response.Health{
-				Type: blockless.MessageHealthCheck,
 				Code: http.StatusOK,
 			}
 

--- a/node/health_internal_test.go
+++ b/node/health_internal_test.go
@@ -80,7 +80,6 @@ func TestNode_Health(t *testing.T) {
 		err = json.Unmarshal(msg.Data, &received)
 		require.NoError(t, err)
 
-		require.Equal(t, blockless.MessageHealthCheck, received.Type)
 		require.Equal(t, http.StatusOK, received.Code)
 	}
 

--- a/node/install.go
+++ b/node/install.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -13,7 +12,7 @@ import (
 	"github.com/blocklessnetwork/b7s/models/response"
 )
 
-func (n *Node) processInstallFunction(ctx context.Context, from peer.ID, payload []byte) error {
+func (n *Node) processInstallFunction(ctx context.Context, from peer.ID, req request.InstallFunction) error {
 
 	// Only workers should respond to function install requests.
 	if n.cfg.Role != blockless.WorkerNode {
@@ -21,16 +20,8 @@ func (n *Node) processInstallFunction(ctx context.Context, from peer.ID, payload
 		return nil
 	}
 
-	// Unpack the request.
-	var req request.InstallFunction
-	err := json.Unmarshal(payload, &req)
-	if err != nil {
-		return fmt.Errorf("could not unpack request: %w", err)
-	}
-	req.From = from
-
 	// Install function.
-	err = n.installFunction(req.CID, req.ManifestURL)
+	err := n.installFunction(req.CID, req.ManifestURL)
 	if err != nil {
 		return fmt.Errorf("could not install function: %w", err)
 	}

--- a/node/install.go
+++ b/node/install.go
@@ -37,7 +37,6 @@ func (n *Node) processInstallFunction(ctx context.Context, from peer.ID, payload
 
 	// Create the response.
 	res := response.InstallFunction{
-		Type:    blockless.MessageInstallFunctionResponse,
 		Code:    codes.Accepted,
 		Message: "installed",
 		CID:     req.CID,

--- a/node/message.go
+++ b/node/message.go
@@ -7,6 +7,8 @@ import (
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetwork/b7s/models/blockless"
 )
 
 type topicInfo struct {
@@ -44,7 +46,7 @@ func (n *Node) subscribeToTopics(ctx context.Context) error {
 }
 
 // send serializes the message and sends it to the specified peer.
-func (n *Node) send(ctx context.Context, to peer.ID, msg interface{}) error {
+func (n *Node) send(ctx context.Context, to peer.ID, msg blockless.Message) error {
 
 	// Serialize the message.
 	payload, err := json.Marshal(msg)

--- a/node/message.go
+++ b/node/message.go
@@ -64,7 +64,7 @@ func (n *Node) send(ctx context.Context, to peer.ID, msg blockless.Message) erro
 }
 
 // sendToMany serializes the message and sends it to a number of peers. It aborts on any error.
-func (n *Node) sendToMany(ctx context.Context, peers []peer.ID, msg interface{}) error {
+func (n *Node) sendToMany(ctx context.Context, peers []peer.ID, msg blockless.Message) error {
 
 	// Serialize the message.
 	payload, err := json.Marshal(msg)
@@ -83,11 +83,11 @@ func (n *Node) sendToMany(ctx context.Context, peers []peer.ID, msg interface{})
 	return nil
 }
 
-func (n *Node) publish(ctx context.Context, msg interface{}) error {
+func (n *Node) publish(ctx context.Context, msg blockless.Message) error {
 	return n.publishToTopic(ctx, DefaultTopic, msg)
 }
 
-func (n *Node) publishToTopic(ctx context.Context, topic string, msg interface{}) error {
+func (n *Node) publishToTopic(ctx context.Context, topic string, msg blockless.Message) error {
 
 	// Serialize the message.
 	payload, err := json.Marshal(msg)

--- a/node/message_internal_test.go
+++ b/node/message_internal_test.go
@@ -107,3 +107,7 @@ type dummyRecord struct {
 	Value       uint64 `json:"value"`
 	Description string `json:"description"`
 }
+
+func (dummyRecord) Type() string {
+	return "MessageDummyRecord"
+}

--- a/node/node.go
+++ b/node/node.go
@@ -1,13 +1,11 @@
 package node
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"sync"
 
 	"github.com/google/uuid"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog"
 
 	"github.com/blocklessnetwork/b7s-attributes/attributes"
@@ -111,39 +109,6 @@ func New(log zerolog.Logger, host *host.Host, peerStore PeerStore, fstore FStore
 // ID returns the ID of this node.
 func (n *Node) ID() string {
 	return n.host.ID().String()
-}
-
-// getHandler returns the appropriate handler function for the given message.
-func (n *Node) getHandler(msgType string) HandlerFunc {
-
-	switch msgType {
-	case blockless.MessageHealthCheck:
-		return n.processHealthCheck
-	case blockless.MessageExecuteResponse:
-		return n.processExecuteResponse
-	case blockless.MessageRollCall:
-		return n.processRollCall
-	case blockless.MessageRollCallResponse:
-		return n.processRollCallResponse
-	case blockless.MessageInstallFunction:
-		return n.processInstallFunction
-	case blockless.MessageInstallFunctionResponse:
-		return n.processInstallFunctionResponse
-	case blockless.MessageFormCluster:
-		return n.processFormCluster
-	case blockless.MessageFormClusterResponse:
-		return n.processFormClusterResponse
-	case blockless.MessageDisbandCluster:
-		return n.processDisbandCluster
-
-	case blockless.MessageExecute:
-		return n.processExecute
-
-	default:
-		return func(_ context.Context, from peer.ID, _ []byte) error {
-			return ErrUnsupportedMessage
-		}
-	}
 }
 
 func newRequestID() (string, error) {

--- a/node/node_integration_test.go
+++ b/node/node_integration_test.go
@@ -147,7 +147,6 @@ func createClient(t *testing.T) *client {
 func (c *client) sendInstallMessage(ctx context.Context, to peer.ID, manifestURL string, cid string) error {
 
 	req := request.InstallFunction{
-		Type:        blockless.MessageInstallFunction,
 		ManifestURL: manifestURL,
 		CID:         cid,
 	}
@@ -168,7 +167,6 @@ func (c *client) sendInstallMessage(ctx context.Context, to peer.ID, manifestURL
 func (c *client) sendExecutionMessage(ctx context.Context, to peer.ID, cid string, method string, consensus consensus.Type, count int) error {
 
 	req := request.Execute{
-		Type: blockless.MessageExecute,
 		Request: execute.Request{
 			FunctionID: cid,
 			Method:     method,

--- a/node/node_internal_test.go
+++ b/node/node_internal_test.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"io"
 	"testing"
@@ -67,25 +66,6 @@ func TestNode_New(t *testing.T) {
 		// Creating a worker node without executor fails.
 		_, err = New(logger, host, peerstore, functionHandler, WithRole(blockless.WorkerNode))
 		require.Error(t, err)
-	})
-}
-
-func TestNode_MessageHandler(t *testing.T) {
-	t.Run("unsupported messages should fail", func(t *testing.T) {
-		t.Parallel()
-
-		const (
-			msgType = "jibberish"
-		)
-
-		node := createNode(t, blockless.HeadNode)
-
-		handlerFunc := node.getHandler(msgType)
-
-		err := handlerFunc(context.Background(), mocks.GenericPeerID, []byte{})
-		require.Error(t, err)
-
-		require.ErrorIs(t, err, ErrUnsupportedMessage)
 	})
 }
 

--- a/node/pipeline.go
+++ b/node/pipeline.go
@@ -1,0 +1,65 @@
+package node
+
+import (
+	"errors"
+
+	"github.com/blocklessnetwork/b7s/models/blockless"
+)
+
+type messagePipeline int
+
+const (
+	subscriptionPipeline messagePipeline = iota + 1
+	directMessagePipeline
+)
+
+var errDisallowedMessage = errors.New("disallowed message")
+
+func (p messagePipeline) String() string {
+	switch p {
+	case subscriptionPipeline:
+		return "Subscription"
+	case directMessagePipeline:
+		return "DirectMessage"
+	default:
+		return "Unknown"
+	}
+}
+
+func allowedMessage(msg string, pipeline messagePipeline) error {
+
+	if pipeline == directMessagePipeline {
+
+		switch msg {
+		// Messages we don't expect as direct messages.
+		case
+			blockless.MessageHealthCheck,
+			blockless.MessageRollCall:
+
+			// Technically we only publish InstallFunction. However, it's handy for tests to support
+			// direct install, and it's somewhat of a low risk.
+
+			return errDisallowedMessage
+
+		default:
+			return nil
+		}
+	}
+
+	switch msg {
+	// Messages we don't allow to be published.
+	case
+		blockless.MessageInstallFunctionResponse,
+		blockless.MessageExecute,
+		blockless.MessageExecuteResponse,
+		blockless.MessageFormCluster,
+		blockless.MessageFormClusterResponse,
+		blockless.MessageDisbandCluster,
+		blockless.MessageRollCallResponse:
+
+		return errDisallowedMessage
+
+	default:
+		return nil
+	}
+}

--- a/node/pipeline_internal_test.go
+++ b/node/pipeline_internal_test.go
@@ -1,0 +1,34 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blocklessnetwork/b7s/models/blockless"
+)
+
+func TestNode_DisallowedMessages(t *testing.T) {
+
+	tests := []struct {
+		message  string
+		pipeline messagePipeline
+	}{
+		// Messages disallowed for publishing.
+		{message: blockless.MessageInstallFunctionResponse, pipeline: subscriptionPipeline},
+		{message: blockless.MessageExecute, pipeline: subscriptionPipeline},
+		{message: blockless.MessageExecuteResponse, pipeline: subscriptionPipeline},
+		{message: blockless.MessageFormCluster, pipeline: subscriptionPipeline},
+		{message: blockless.MessageFormClusterResponse, pipeline: subscriptionPipeline},
+		{message: blockless.MessageDisbandCluster, pipeline: subscriptionPipeline},
+
+		// Messages disallowed for direct sending.
+		{message: blockless.MessageHealthCheck, pipeline: directMessagePipeline},
+		{message: blockless.MessageRollCall, pipeline: directMessagePipeline},
+	}
+
+	for _, test := range tests {
+		err := allowedMessage(test.message, test.pipeline)
+		require.ErrorIsf(t, err, errDisallowedMessage, "message: %s, pipeline: %s", test.message, test.pipeline)
+	}
+}

--- a/node/process.go
+++ b/node/process.go
@@ -6,33 +6,66 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/request"
+	"github.com/blocklessnetwork/b7s/models/response"
 )
+
+// TODO: Set up a chain: message ID => model => handler
 
 // processMessage will determine which message was received and how to process it.
 func (n *Node) processMessage(ctx context.Context, from peer.ID, payload []byte) error {
 
 	// Determine message type.
-	msgType, err := getMessageType(payload)
+	msg, err := unpackMessage(payload)
 	if err != nil {
-		return fmt.Errorf("could not determine message type: %w", err)
+		return fmt.Errorf("could not unpack message: %w", err)
 	}
+
+	msgType := msg.Type()
 
 	n.log.Trace().Str("peer", from.String()).Str("message", msgType).Msg("received message from peer")
 
 	// Get the registered handler for the message.
-	handler := n.getHandler(msgType)
+	switch msgType {
 
-	// Invoke the aprropriate handler to process the message.
-	return handler(ctx, from, payload)
-}
+	case blockless.MessageHealthCheck:
+		return n.processHealthCheck(ctx, from, msg.(response.Health))
 
-type baseMessage struct {
-	Type string `json:"type,omitempty"`
+	case blockless.MessageInstallFunction:
+		return n.processInstallFunction(ctx, from, msg.(request.InstallFunction))
+	case blockless.MessageInstallFunctionResponse:
+		return n.processInstallFunctionResponse(ctx, from, msg.(response.InstallFunction))
+
+	case blockless.MessageRollCall:
+		return n.processRollCall(ctx, from, msg.(request.RollCall))
+	case blockless.MessageRollCallResponse:
+		return n.processRollCallResponse(ctx, from, msg.(response.RollCall))
+
+	case blockless.MessageExecute:
+		return n.processExecute(ctx, from, msg.(request.Execute))
+	case blockless.MessageExecuteResponse:
+		return n.processExecuteResponse(ctx, from, msg.(response.Execute))
+
+	case blockless.MessageFormCluster:
+		return n.processFormCluster(ctx, from, msg.(request.FormCluster))
+	case blockless.MessageFormClusterResponse:
+		return n.processFormClusterResponse(ctx, from, msg.(response.FormCluster))
+	case blockless.MessageDisbandCluster:
+		return n.processDisbandCluster(ctx, from, msg.(request.DisbandCluster))
+
+	default:
+		return fmt.Errorf("unsupported message type (from: %s): %s", from.String(), msgType)
+	}
 }
 
 // getMessageType will return the `type` string field from the JSON payload.
 func getMessageType(payload []byte) (string, error) {
 
+	type baseMessage struct {
+		Type string `json:"type,omitempty"`
+	}
 	var message baseMessage
 	err := json.Unmarshal(payload, &message)
 	if err != nil {
@@ -40,4 +73,51 @@ func getMessageType(payload []byte) (string, error) {
 	}
 
 	return message.Type, nil
+}
+
+func unpackMessage(payload []byte) (blockless.Message, error) {
+
+	// Determine message type.
+	msgType, err := getMessageType(payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not determine message type: %w", err)
+	}
+
+	switch msgType {
+
+	case blockless.MessageHealthCheck:
+		return unmarshalJSON[response.Health](payload)
+	case blockless.MessageInstallFunction:
+		return unmarshalJSON[request.InstallFunction](payload)
+	case blockless.MessageInstallFunctionResponse:
+		return unmarshalJSON[response.InstallFunction](payload)
+	case blockless.MessageRollCall:
+		return unmarshalJSON[request.RollCall](payload)
+	case blockless.MessageRollCallResponse:
+		return unmarshalJSON[response.RollCall](payload)
+	case blockless.MessageExecute:
+		return unmarshalJSON[request.Execute](payload)
+	case blockless.MessageExecuteResponse:
+		return unmarshalJSON[response.Execute](payload)
+	case blockless.MessageFormCluster:
+		return unmarshalJSON[request.FormCluster](payload)
+	case blockless.MessageFormClusterResponse:
+		return unmarshalJSON[response.FormCluster](payload)
+	case blockless.MessageDisbandCluster:
+		return unmarshalJSON[request.DisbandCluster](payload)
+
+	default:
+		return nil, fmt.Errorf("unknown message type: %w", err)
+	}
+}
+
+func unmarshalJSON[T any](payload []byte) (T, error) {
+
+	var obj T
+	err := json.Unmarshal(payload, &obj)
+	if err != nil {
+		return obj, fmt.Errorf("could not unmarshal message: %w", err)
+	}
+
+	return obj, nil
 }

--- a/node/queue_test.go
+++ b/node/queue_test.go
@@ -15,10 +15,12 @@ func TestRollCallQueue(t *testing.T) {
 	var (
 		requestID = "dummy-request-id"
 
-		res = response.RollCall{
-			From:       mocks.GenericPeerID,
-			RequestID:  requestID,
-			FunctionID: "dummy-function-id",
+		res = rollCallResponse{
+			From: mocks.GenericPeerID,
+			RollCall: response.RollCall{
+				RequestID:  requestID,
+				FunctionID: "dummy-function-id",
+			},
 		}
 	)
 

--- a/node/queue_test.go
+++ b/node/queue_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/response"
 	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
@@ -17,7 +16,6 @@ func TestRollCallQueue(t *testing.T) {
 		requestID = "dummy-request-id"
 
 		res = response.RollCall{
-			Type:       blockless.MessageRollCallResponse,
 			From:       mocks.GenericPeerID,
 			RequestID:  requestID,
 			FunctionID: "dummy-function-id",

--- a/node/rest.go
+++ b/node/rest.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 	"github.com/blocklessnetwork/b7s/models/execute"
 	"github.com/blocklessnetwork/b7s/models/request"
@@ -75,7 +74,6 @@ func createInstallMessageFromURI(uri string) (request.InstallFunction, error) {
 	}
 
 	msg := request.InstallFunction{
-		Type:        blockless.MessageInstallFunction,
 		ManifestURL: uri,
 		CID:         cid,
 	}
@@ -87,7 +85,6 @@ func createInstallMessageFromURI(uri string) (request.InstallFunction, error) {
 func createInstallMessageFromCID(cid string) request.InstallFunction {
 
 	req := request.InstallFunction{
-		Type:        blockless.MessageInstallFunction,
 		ManifestURL: manifestURLFromCID(cid),
 		CID:         cid,
 	}

--- a/node/rest_internal_test.go
+++ b/node/rest_internal_test.go
@@ -25,7 +25,6 @@ func TestNode_InstallMessageFromCID(t *testing.T) {
 
 	req := createInstallMessageFromCID(cid)
 
-	require.Equal(t, blockless.MessageInstallFunction, req.Type)
 	require.Equal(t, cid, req.CID)
 	require.Equal(t, expectedManifestURL, req.ManifestURL)
 }

--- a/node/roll_call.go
+++ b/node/roll_call.go
@@ -57,7 +57,6 @@ func (n *Node) processRollCall(ctx context.Context, from peer.ID, payload []byte
 
 	// Base response to return.
 	res := response.RollCall{
-		Type:       blockless.MessageRollCallResponse,
 		FunctionID: req.FunctionID,
 		RequestID:  req.RequestID,
 		Code:       codes.Error, // CodeError by default, changed if everything goes well.
@@ -131,7 +130,7 @@ func (n *Node) executeRollCall(
 
 	// Limit for how long we wait for responses.
 	t := n.cfg.RollCallTimeout
-	if(timeout > 0) {
+	if timeout > 0 {
 		t = time.Duration(timeout) * time.Second
 	}
 
@@ -148,7 +147,7 @@ rollCallResponseLoop:
 		case <-tctx.Done():
 
 			// -1 means we'll take any peers reporting
-			if (len(reportingPeers) >= 1 && nodeCount == -1) {
+			if len(reportingPeers) >= 1 && nodeCount == -1 {
 				log.Info().Msg("enough peers reported for roll call")
 				break rollCallResponseLoop
 			}
@@ -192,7 +191,6 @@ func (n *Node) publishRollCall(ctx context.Context, requestID string, functionID
 
 	// Create a roll call request.
 	rollCall := request.RollCall{
-		Type:       blockless.MessageRollCall,
 		Origin:     n.host.ID(),
 		FunctionID: functionID,
 		RequestID:  requestID,

--- a/node/roll_call.go
+++ b/node/roll_call.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -16,21 +15,13 @@ import (
 	"github.com/blocklessnetwork/b7s/models/response"
 )
 
-func (n *Node) processRollCall(ctx context.Context, from peer.ID, payload []byte) error {
+func (n *Node) processRollCall(ctx context.Context, from peer.ID, req request.RollCall) error {
 
 	// Only workers respond to roll calls at the moment.
 	if n.cfg.Role != blockless.WorkerNode {
 		n.log.Debug().Msg("skipping roll call as a non-worker node")
 		return nil
 	}
-
-	// Unpack the request.
-	var req request.RollCall
-	err := json.Unmarshal(payload, &req)
-	if err != nil {
-		return fmt.Errorf("could not unpack request: %w", err)
-	}
-	req.From = from
 
 	log := n.log.With().Str("request", req.RequestID).Str("origin", req.Origin.String()).Str("function", req.FunctionID).Logger()
 	log.Debug().Msg("received roll call request")

--- a/node/roll_call_internal_test.go
+++ b/node/roll_call_internal_test.go
@@ -30,7 +30,7 @@ func TestNode_RollCall(t *testing.T) {
 		}
 
 		node := createNode(t, blockless.HeadNode)
-		err := node.processRollCall(context.Background(), mocks.GenericPeerID, serialize(t, rollCallReq))
+		err := node.processRollCall(context.Background(), mocks.GenericPeerID, rollCallReq)
 		require.NoError(t, err)
 	})
 
@@ -68,7 +68,7 @@ func TestNode_RollCall(t *testing.T) {
 			require.Equal(t, codes.Accepted, received.Code)
 		})
 
-		err = node.processRollCall(context.Background(), receiver.ID(), serialize(t, rollCallReq))
+		err = node.processRollCall(context.Background(), receiver.ID(), rollCallReq)
 		require.NoError(t, err)
 
 		wg.Wait()
@@ -114,7 +114,7 @@ func TestNode_RollCall(t *testing.T) {
 			require.Equal(t, codes.Error, received.Code)
 		})
 
-		err = node.processRollCall(context.Background(), receiver.ID(), serialize(t, rollCallReq))
+		err = node.processRollCall(context.Background(), receiver.ID(), rollCallReq)
 		require.Error(t, err)
 
 		wg.Wait()
@@ -163,7 +163,7 @@ func TestNode_RollCall(t *testing.T) {
 			require.Equal(t, codes.Accepted, received.Code)
 		})
 
-		err = node.processRollCall(context.Background(), receiver.ID(), serialize(t, rollCallReq))
+		err = node.processRollCall(context.Background(), receiver.ID(), rollCallReq)
 		require.NoError(t, err)
 
 		wg.Wait()
@@ -212,7 +212,7 @@ func TestNode_RollCall(t *testing.T) {
 			require.Equal(t, codes.Error, received.Code)
 		})
 
-		err = node.processRollCall(context.Background(), receiver.ID(), serialize(t, rollCallReq))
+		err = node.processRollCall(context.Background(), receiver.ID(), rollCallReq)
 		require.Error(t, err)
 
 		wg.Wait()

--- a/node/roll_call_internal_test.go
+++ b/node/roll_call_internal_test.go
@@ -25,7 +25,6 @@ func TestNode_RollCall(t *testing.T) {
 		t.Parallel()
 
 		rollCallReq := request.RollCall{
-			Type:       blockless.MessageRollCall,
 			FunctionID: "dummy-function-id",
 			RequestID:  mocks.GenericUUID.String(),
 		}
@@ -44,7 +43,6 @@ func TestNode_RollCall(t *testing.T) {
 		require.NoError(t, err)
 
 		rollCallReq := request.RollCall{
-			Type:       blockless.MessageRollCall,
 			FunctionID: "dummy-function-id",
 			RequestID:  mocks.GenericUUID.String(),
 			Origin:     receiver.ID(),
@@ -65,8 +63,6 @@ func TestNode_RollCall(t *testing.T) {
 			from := stream.Conn().RemotePeer()
 			require.Equal(t, node.host.ID(), from)
 
-			require.Equal(t, blockless.MessageRollCallResponse, received.Type)
-
 			require.Equal(t, rollCallReq.FunctionID, received.FunctionID)
 			require.Equal(t, rollCallReq.RequestID, received.RequestID)
 			require.Equal(t, codes.Accepted, received.Code)
@@ -86,7 +82,6 @@ func TestNode_RollCall(t *testing.T) {
 		require.NoError(t, err)
 
 		rollCallReq := request.RollCall{
-			Type:       blockless.MessageRollCall,
 			FunctionID: "dummy-function-id",
 			RequestID:  mocks.GenericUUID.String(),
 			Origin:     receiver.ID(),
@@ -114,8 +109,6 @@ func TestNode_RollCall(t *testing.T) {
 			from := stream.Conn().RemotePeer()
 			require.Equal(t, node.host.ID(), from)
 
-			require.Equal(t, blockless.MessageRollCallResponse, received.Type)
-
 			require.Equal(t, rollCallReq.FunctionID, received.FunctionID)
 			require.Equal(t, rollCallReq.RequestID, received.RequestID)
 			require.Equal(t, codes.Error, received.Code)
@@ -135,7 +128,6 @@ func TestNode_RollCall(t *testing.T) {
 		require.NoError(t, err)
 
 		rollCallReq := request.RollCall{
-			Type:       blockless.MessageRollCall,
 			FunctionID: "dummy-function-id",
 			RequestID:  mocks.GenericUUID.String(),
 			Origin:     receiver.ID(),
@@ -166,8 +158,6 @@ func TestNode_RollCall(t *testing.T) {
 			from := stream.Conn().RemotePeer()
 			require.Equal(t, node.host.ID(), from)
 
-			require.Equal(t, blockless.MessageRollCallResponse, received.Type)
-
 			require.Equal(t, rollCallReq.FunctionID, received.FunctionID)
 			require.Equal(t, rollCallReq.RequestID, received.RequestID)
 			require.Equal(t, codes.Accepted, received.Code)
@@ -187,7 +177,6 @@ func TestNode_RollCall(t *testing.T) {
 		require.NoError(t, err)
 
 		rollCallReq := request.RollCall{
-			Type:       blockless.MessageRollCall,
 			FunctionID: "dummy-function-id",
 			RequestID:  mocks.GenericUUID.String(),
 			Origin:     receiver.ID(),
@@ -217,8 +206,6 @@ func TestNode_RollCall(t *testing.T) {
 
 			from := stream.Conn().RemotePeer()
 			require.Equal(t, node.host.ID(), from)
-
-			require.Equal(t, blockless.MessageRollCallResponse, received.Type)
 
 			require.Equal(t, rollCallReq.FunctionID, received.FunctionID)
 			require.Equal(t, rollCallReq.RequestID, received.RequestID)
@@ -284,7 +271,6 @@ func TestNode_RollCall(t *testing.T) {
 		err = json.Unmarshal(msg.Data, &received)
 		require.NoError(t, err)
 
-		require.Equal(t, blockless.MessageRollCall, received.Type)
 		require.Equal(t, functionID, received.FunctionID)
 		require.Equal(t, requestID, received.RequestID)
 	})

--- a/node/run.go
+++ b/node/run.go
@@ -98,8 +98,6 @@ func (n *Node) Run(ctx context.Context) error {
 		}(name, topic.subscription)
 	}
 
-	n.log.Debug().Msg("waiting for workers")
-
 	workers.Wait()
 
 	n.log.Debug().Msg("waiting for messages being processed")

--- a/node/run.go
+++ b/node/run.go
@@ -89,7 +89,7 @@ func (n *Node) Run(ctx context.Context) error {
 					defer n.wg.Done()
 					defer func() { <-n.sema }()
 
-					err = n.processMessage(ctx, msg.ReceivedFrom, msg.Data)
+					err = n.processMessage(ctx, msg.ReceivedFrom, msg.GetData(), subscriptionPipeline)
 					if err != nil {
 						n.log.Error().Err(err).Str("id", msg.ID).Str("peer", msg.ReceivedFrom.String()).Msg("could not process message")
 					}
@@ -122,9 +122,9 @@ func (n *Node) listenDirectMessages(ctx context.Context) {
 			return
 		}
 
-		n.log.Debug().Str("peer", from.String()).Msg("received direct message")
+		n.log.Trace().Str("peer", from.String()).Msg("received direct message")
 
-		err = n.processMessage(ctx, from, msg)
+		err = n.processMessage(ctx, from, msg, directMessagePipeline)
 		if err != nil {
 			n.log.Error().Err(err).Str("peer", from.String()).Msg("could not process direct message")
 		}

--- a/node/worker_execute.go
+++ b/node/worker_execute.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 	"github.com/blocklessnetwork/b7s/models/execute"
 	"github.com/blocklessnetwork/b7s/models/request"
@@ -52,7 +51,6 @@ func (n *Node) workerProcessExecute(ctx context.Context, from peer.ID, payload [
 
 	// Create the execution response from the execution result.
 	res := response.Execute{
-		Type:      blockless.MessageExecuteResponse,
 		Code:      code,
 		RequestID: requestID,
 		Results: execute.ResultMap{


### PR DESCRIPTION
This code makes a number of changes to the message types and message handling code.

- messages no longer have an explicit `Type` field that can be set - having this and having to set it manually is prone to error (someone might use a certain model and inadvertently set the wrong message type/ID). Now this is done automagically on JSON marshalling
- messages no longer have an explicit `From` field telling us who sent the message - this is handled by the node
- invalid/unused message types are removed
- we use generics (!) to simplify message decoding, and
- message processing functions now receive actual types they need and not an obscure byte slice they need to manually unmarshal
- some verbosity added by defining custom marshallers but wanted to keep backwards compatibility for the moment and have the message data and message `type` field as top-level fields; worth it for less clutter in node package IMO
- added differentiation between published messages and those we receive via direct communication; added some validation there - we don't allow just any message to be published as it could lead to issues (e.g. random worker publishes `MessageExecute` or `MessageDisbandCluster`)
- fix handling of workspace/peer db/function db flags - config/default values are now handled correctly