### PR TITLE
Fix archive extraction - skip entries that attempt directory traversal

### DIFF
--- a/cmd/manager/bin.go
+++ b/cmd/manager/bin.go
@@ -12,6 +12,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 func installBinary(url, folder string) {
@@ -49,6 +50,12 @@ func installBinary(url, folder string) {
 		}
 		if err != nil {
 			log.Fatal(err)
+		}
+
+		// Do not allow directory traversal as it's a security issue.
+		if strings.Contains(header.Name, "..") {
+			log.Printf("skipping archive entry with disallowed path")
+			continue
 		}
 
 		path := filepath.Join(targetPath, header.Name)

--- a/fstore/gzip.go
+++ b/fstore/gzip.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func (h *FStore) unpackArchive(filename string, destination string) error {
@@ -53,6 +54,12 @@ func (h *FStore) unpackArchive(filename string, destination string) error {
 			}
 
 			break
+		}
+
+		// Do not allow directory traversal as it's a security issue.
+		if strings.Contains(entry.Name, "..") {
+			h.log.Warn().Str("archive", filename).Str("entry", entry.Name).Msg("skipping archive entry with disallowed path")
+			continue
 		}
 
 		typ := entry.Typeflag


### PR DESCRIPTION
This PR introduces fixes for ZipSlip vulnerabilities reported [here](https://github.com/blocklessnetwork/b7s/security/code-scanning/1) and [here](https://github.com/blocklessnetwork/b7s/security/code-scanning/2).