### PR TITLE
Worker executor response signature support

### DIFF
--- a/consensus/pbft/execute.go
+++ b/consensus/pbft/execute.go
@@ -1,6 +1,7 @@
 package pbft
 
 import (
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -98,6 +99,7 @@ func (r *Replica) execute(view uint, sequence uint, digest string) error {
 			RequestTimestamp: request.Timestamp,
 			Replica:          r.id,
 		},
+		Signature: hex.EncodeToString(res.Signature),
 	}
 
 	// Save this executions in case it's requested again.

--- a/executor/config.go
+++ b/executor/config.go
@@ -11,6 +11,10 @@ type ExecutionSigner interface {
 	Sign(execute.Request, execute.RuntimeOutput) ([]byte, error)
 }
 
+type MetaProvider interface {
+	WithMetadata(execute.Request, execute.RuntimeOutput) (interface{}, error)
+}
+
 // defaultConfig used to create Executor.
 var defaultConfig = Config{
 	WorkDir:         "workspace",
@@ -30,6 +34,7 @@ type Config struct {
 	FS              afero.Fs        // FS accessor
 	Limiter         Limiter         // Resource limiter for executed processes
 	Signer          ExecutionSigner // Signer for the executor
+	MetaProvider    MetaProvider    // Metadata provider for the executor
 }
 
 type Option func(*Config)
@@ -73,5 +78,12 @@ func WithLimiter(limiter Limiter) Option {
 func WithSigner(signer ExecutionSigner) Option {
 	return func(cfg *Config) {
 		cfg.Signer = signer
+	}
+}
+
+// WithMetaProvider sets the metadata provider for the executor.
+func WithMetaProvider(meta MetaProvider) Option {
+	return func(cfg *Config) {
+		cfg.MetaProvider = meta
 	}
 }

--- a/executor/config.go
+++ b/executor/config.go
@@ -4,26 +4,32 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
+
+type ExecutionSigner interface {
+	Sign(execute.Request, execute.RuntimeOutput) ([]byte, error)
+}
 
 // defaultConfig used to create Executor.
 var defaultConfig = Config{
-	WorkDir:        "workspace",
-	RuntimeDir:     "",
-	ExecutableName: blockless.RuntimeCLI(),
-	FS:             afero.NewOsFs(),
-	Limiter:        &noopLimiter{},
+	WorkDir:         "workspace",
+	RuntimeDir:      "",
+	ExecutableName:  blockless.RuntimeCLI(),
+	FS:              afero.NewOsFs(),
+	Limiter:         &noopLimiter{},
 	DriversRootPath: "",
 }
 
 // Config represents the Executor configuration.
 type Config struct {
-	WorkDir        string   // directory where files needed for the execution are stored
-	RuntimeDir     string   // directory where the executable can be found
-	ExecutableName string   // name for the executable
-	DriversRootPath string // where are cgi drivers stored
-	FS             afero.Fs // FS accessor
-	Limiter        Limiter  // Resource limiter for executed processes
+	WorkDir         string          // directory where files needed for the execution are stored
+	RuntimeDir      string          // directory where the executable can be found
+	ExecutableName  string          // name for the executable
+	DriversRootPath string          // where are cgi drivers stored
+	FS              afero.Fs        // FS accessor
+	Limiter         Limiter         // Resource limiter for executed processes
+	Signer          ExecutionSigner // Signer for the executor
 }
 
 type Option func(*Config)
@@ -60,5 +66,12 @@ func WithExecutableName(name string) Option {
 func WithLimiter(limiter Limiter) Option {
 	return func(cfg *Config) {
 		cfg.Limiter = limiter
+	}
+}
+
+// WithSigner sets the signer for the executor.
+func WithSigner(signer ExecutionSigner) Option {
+	return func(cfg *Config) {
+		cfg.Signer = signer
 	}
 }

--- a/models/execute/response.go
+++ b/models/execute/response.go
@@ -15,6 +15,7 @@ type Result struct {
 	Result    RuntimeOutput `json:"result"`
 	RequestID string        `json:"request_id"`
 	Usage     Usage         `json:"usage,omitempty"`
+	Signature []byte        `json:"signature,omitempty"`
 }
 
 // Cluster represents the set of peers that executed the request.

--- a/models/execute/response.go
+++ b/models/execute/response.go
@@ -16,6 +16,7 @@ type Result struct {
 	RequestID string        `json:"request_id"`
 	Usage     Usage         `json:"usage,omitempty"`
 	Signature []byte        `json:"signature,omitempty"`
+	Metadata  interface{}   `json:"metadata,omitempty"`
 }
 
 // Cluster represents the set of peers that executed the request.

--- a/models/execute/runtime.go
+++ b/models/execute/runtime.go
@@ -6,12 +6,12 @@ const (
 
 // RuntimeConfig represents the CLI flags supported by the runtime
 type BLSRuntimeConfig struct {
-	Entry         string `json:"entry,omitempty"`
-	ExecutionTime uint64 `json:"run_time,omitempty"`
-	DebugInfo     bool   `json:"debug_info,omitempty"`
-	Fuel          uint64 `json:"limited_fuel,omitempty"`
-	Memory        uint64 `json:"limited_memory,omitempty"`
-	Logger        string `json:"runtime_logger,omitempty"`
+	Entry           string `json:"entry,omitempty"`
+	ExecutionTime   uint64 `json:"run_time,omitempty"`
+	DebugInfo       bool   `json:"debug_info,omitempty"`
+	Fuel            uint64 `json:"limited_fuel,omitempty"`
+	Memory          uint64 `json:"limited_memory,omitempty"`
+	Logger          string `json:"runtime_logger,omitempty"`
 	DriversRootPath string `json:"drivers_root_path,omitempty"`
 	// Fields not allowed to be set in the request.
 	Input  string `json:"-"`
@@ -29,5 +29,5 @@ const (
 	BLSRuntimeFlagLogger        = "runtime-logger"
 	BLSRuntimeFlagPermission    = "permission"
 	BLSRuntimeFlagEnv           = "env"
-	BLSRuntimeFlagDrivers 		= "drivers-root-path"
+	BLSRuntimeFlagDrivers       = "drivers-root-path"
 )

--- a/node/aggregate/aggregate.go
+++ b/node/aggregate/aggregate.go
@@ -19,12 +19,15 @@ type Result struct {
 	Frequency float64 `json:"frequency,omitempty"`
 	// Signature of this result
 	Signature []byte `json:"signature,omitempty"`
+	// Metadata is used to store additional information about the result.
+	Metadata interface{} `json:"metadata,omitempty"`
 }
 
 type resultStats struct {
 	seen      uint
 	peers     []peer.ID
 	signature []byte
+	metadata  interface{}
 }
 
 func Aggregate(results execute.ResultMap) Results {
@@ -46,12 +49,14 @@ func Aggregate(results execute.ResultMap) Results {
 				seen:      0,
 				peers:     make([]peer.ID, 0),
 				signature: res.Signature,
+				metadata:  res.Metadata,
 			}
 		}
 
 		stat.seen++
 		stat.peers = append(stat.peers, executingPeer)
 		stat.signature = res.Signature
+		stat.metadata = res.Metadata
 
 		stats[output] = stat
 	}
@@ -65,6 +70,7 @@ func Aggregate(results execute.ResultMap) Results {
 			Peers:     stat.peers,
 			Frequency: 100 * float64(stat.seen) / float64(total),
 			Signature: stat.signature,
+			Metadata:  stat.metadata,
 		}
 
 		aggregated = append(aggregated, aggr)

--- a/node/aggregate/aggregate.go
+++ b/node/aggregate/aggregate.go
@@ -17,11 +17,14 @@ type Result struct {
 	Peers []peer.ID `json:"peers,omitempty"`
 	// How frequent was this result, in percentages.
 	Frequency float64 `json:"frequency,omitempty"`
+	// Signature of this result
+	Signature []byte `json:"signature,omitempty"`
 }
 
 type resultStats struct {
-	seen  uint
-	peers []peer.ID
+	seen      uint
+	peers     []peer.ID
+	signature []byte
 }
 
 func Aggregate(results execute.ResultMap) Results {
@@ -40,13 +43,15 @@ func Aggregate(results execute.ResultMap) Results {
 		stat, ok := stats[output]
 		if !ok {
 			stats[output] = resultStats{
-				seen:  0,
-				peers: make([]peer.ID, 0),
+				seen:      0,
+				peers:     make([]peer.ID, 0),
+				signature: res.Signature,
 			}
 		}
 
 		stat.seen++
 		stat.peers = append(stat.peers, executingPeer)
+		stat.signature = res.Signature
 
 		stats[output] = stat
 	}
@@ -59,6 +64,7 @@ func Aggregate(results execute.ResultMap) Results {
 			Result:    res,
 			Peers:     stat.peers,
 			Frequency: 100 * float64(stat.seen) / float64(total),
+			Signature: stat.signature,
 		}
 
 		aggregated = append(aggregated, aggr)

--- a/node/worker_execute.go
+++ b/node/worker_execute.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -47,6 +48,7 @@ func (n *Node) workerProcessExecute(ctx context.Context, from peer.ID, req reque
 		Results: execute.ResultMap{
 			n.host.ID(): result,
 		},
+		Signature: hex.EncodeToString(result.Signature),
 	}
 
 	// Send the response, whatever it may be (success or failure).


### PR DESCRIPTION
# Context

This PR adds support for b7s workers to optionally support signing responses (using any arbitrarily provided signature scheme/function as an executor option).
Additionally, support is added for providing additional relevant metadata by workers - as a worker executor option.

- This is specifically useful when using b7s node as a lib, where you'd want the worker to sign responses with custom provided signature scheme/algorithm (such as in the case of using b7s as AVS)
- With this change, the head node would return aggregated worker responses, in addition to their respective signatures (assuming the workers opted into signing with some desired scheme)
- The same applies for metadata, which can be optionally added/injected and then returned in aggregated response from the head-node