### PR TITLE
Worker executor response metadata support 

### DIFF
--- a/api/execute_test.go
+++ b/api/execute_test.go
@@ -19,7 +19,7 @@ import (
 func TestAPI_Execute(t *testing.T) {
 
 	executionResult := execute.Result{
-		Result: execute.RuntimeOutput{
+		Output: execute.RuntimeOutput{
 			Stdout:   "dummy-failed-execution-result",
 			Stderr:   "dummy-failed-execution-log",
 			ExitCode: 0,
@@ -34,7 +34,7 @@ func TestAPI_Execute(t *testing.T) {
 	node.ExecuteFunctionFunc = func(context.Context, execute.Request, string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
 
 		res := execute.ResultMap{
-			mocks.GenericPeerID: executionResult,
+			mocks.GenericPeerID: execute.NodeExecutionResult{Result: executionResult},
 		}
 
 		cluster := execute.Cluster{
@@ -65,7 +65,7 @@ func TestAPI_Execute(t *testing.T) {
 	require.Equal(t, res.Cluster.Peers, peerIDs)
 
 	require.Len(t, res.Results, 1)
-	require.Equal(t, executionResult.Result, res.Results[0].Result)
+	require.Equal(t, executionResult.Output, res.Results[0].Result)
 	require.Equal(t, float64(100), res.Results[0].Frequency)
 	require.Equal(t, peerIDs, res.Results[0].Peers)
 
@@ -75,7 +75,7 @@ func TestAPI_Execute(t *testing.T) {
 func TestAPI_Execute_HandlesErrors(t *testing.T) {
 
 	executionResult := execute.Result{
-		Result: execute.RuntimeOutput{
+		Output: execute.RuntimeOutput{
 			Stdout:   "dummy-failed-execution-result",
 			Stderr:   "dummy-failed-execution-log",
 			ExitCode: 1,
@@ -88,7 +88,7 @@ func TestAPI_Execute_HandlesErrors(t *testing.T) {
 	node.ExecuteFunctionFunc = func(context.Context, execute.Request, string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
 
 		res := execute.ResultMap{
-			mocks.GenericPeerID: executionResult,
+			mocks.GenericPeerID: execute.NodeExecutionResult{Result: executionResult},
 		}
 
 		return expectedCode, "", res, execute.Cluster{}, mocks.GenericError
@@ -112,7 +112,7 @@ func TestAPI_Execute_HandlesErrors(t *testing.T) {
 	require.Equal(t, expectedCode.String(), res.Code)
 
 	require.Len(t, res.Results, 1)
-	require.Equal(t, executionResult.Result, res.Results[0].Result)
+	require.Equal(t, executionResult.Output, res.Results[0].Result)
 	require.Equal(t, float64(100), res.Results[0].Frequency)
 	require.Len(t, res.Results[0].Peers, 1)
 	require.Equal(t, mocks.GenericPeerID, res.Results[0].Peers[0])

--- a/consensus/pbft/execute.go
+++ b/consensus/pbft/execute.go
@@ -1,6 +1,7 @@
 package pbft
 
 import (
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -98,6 +99,7 @@ func (r *Replica) execute(view uint, sequence uint, digest string) error {
 			RequestTimestamp: request.Timestamp,
 			Replica:          r.id,
 		},
+		Signature: hex.EncodeToString(res.Signature),
 	}
 
 	// Save this executions in case it's requested again.

--- a/consensus/pbft/execute.go
+++ b/consensus/pbft/execute.go
@@ -1,7 +1,6 @@
 package pbft
 
 import (
-	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -71,7 +70,7 @@ func (r *Replica) execute(view uint, sequence uint, digest string) error {
 
 	log.Info().Msg("executing request")
 
-	res, err := r.executor.ExecuteFunction(request.ID, request.Execute)
+	res, meta, err := r.executor.ExecuteFunction(request.ID, request.Execute)
 	if err != nil {
 		log.Error().Err(err).Msg("execution failed")
 	}
@@ -92,14 +91,13 @@ func (r *Replica) execute(view uint, sequence uint, digest string) error {
 		Code:      res.Code,
 		RequestID: request.ID,
 		Results: execute.ResultMap{
-			r.id: res,
+			r.id: execute.NodeExecutionResult{Result: res, Metadata: meta},
 		},
 		PBFT: response.PBFTResultInfo{
 			View:             r.view,
 			RequestTimestamp: request.Timestamp,
 			Replica:          r.id,
 		},
-		Signature: hex.EncodeToString(res.Signature),
 	}
 
 	// Save this executions in case it's requested again.

--- a/consensus/raft/fsm.go
+++ b/consensus/raft/fsm.go
@@ -56,7 +56,7 @@ func (f fsmExecutor) Apply(log *raft.Log) interface{} {
 
 	f.log.Info().Str("request", logEntry.RequestID).Str("function", logEntry.Execute.FunctionID).Msg("FSM executing function")
 
-	res, err := f.executor.ExecuteFunction(logEntry.RequestID, logEntry.Execute)
+	res, _, err := f.executor.ExecuteFunction(logEntry.RequestID, logEntry.Execute) // ignore meta
 	if err != nil {
 		return fmt.Errorf("could not execute function: %w", err)
 	}

--- a/executor/config.go
+++ b/executor/config.go
@@ -7,12 +7,8 @@ import (
 	"github.com/blocklessnetwork/b7s/models/execute"
 )
 
-type ExecutionSigner interface {
-	Sign(execute.Request, execute.RuntimeOutput) ([]byte, error)
-}
-
 type MetaProvider interface {
-	WithMetadata(execute.Request, execute.RuntimeOutput) (interface{}, error)
+	WithMetadata(execute.Request, execute.RuntimeOutput) (any, error)
 }
 
 // defaultConfig used to create Executor.
@@ -27,14 +23,13 @@ var defaultConfig = Config{
 
 // Config represents the Executor configuration.
 type Config struct {
-	WorkDir         string          // directory where files needed for the execution are stored
-	RuntimeDir      string          // directory where the executable can be found
-	ExecutableName  string          // name for the executable
-	DriversRootPath string          // where are cgi drivers stored
-	FS              afero.Fs        // FS accessor
-	Limiter         Limiter         // Resource limiter for executed processes
-	Signer          ExecutionSigner // Signer for the executor
-	MetaProvider    MetaProvider    // Metadata provider for the executor
+	WorkDir         string       // directory where files needed for the execution are stored
+	RuntimeDir      string       // directory where the executable can be found
+	ExecutableName  string       // name for the executable
+	DriversRootPath string       // where are cgi drivers stored
+	FS              afero.Fs     // FS accessor
+	Limiter         Limiter      // Resource limiter for executed processes
+	MetaProvider    MetaProvider // Metadata provider for the executor
 }
 
 type Option func(*Config)
@@ -71,13 +66,6 @@ func WithExecutableName(name string) Option {
 func WithLimiter(limiter Limiter) Option {
 	return func(cfg *Config) {
 		cfg.Limiter = limiter
-	}
-}
-
-// WithSigner sets the signer for the executor.
-func WithSigner(signer ExecutionSigner) Option {
-	return func(cfg *Config) {
-		cfg.Signer = signer
 	}
 }
 

--- a/executor/config.go
+++ b/executor/config.go
@@ -11,6 +11,10 @@ type ExecutionSigner interface {
 	Sign(execute.Request, execute.RuntimeOutput) ([]byte, error)
 }
 
+type MetaProvider interface {
+	WithMetadata(execute.Request, execute.RuntimeOutput) (interface{}, error)
+}
+
 // defaultConfig used to create Executor.
 var defaultConfig = Config{
 	WorkDir:         "workspace",
@@ -30,6 +34,7 @@ type Config struct {
 	FS              afero.Fs        // FS accessor
 	Limiter         Limiter         // Resource limiter for executed processes
 	Signer          ExecutionSigner // Signer for the executor
+	MetaProvider    MetaProvider    // Metadata provider for the executor
 }
 
 type Option func(*Config)
@@ -73,5 +78,12 @@ func WithLimiter(limiter Limiter) Option {
 func WithSigner(signer ExecutionSigner) Option {
 	return func(cfg *Config) {
 		cfg.Signer = signer
+	}
+}
+
+// WithMetaProvider sets the metadata provider for the executor.
+func WithMetaProvider(meta MetaProvider) Option {
+	return func(cfg *Config) {
+		cfg.MetaProvider = meta
 	}
 }

--- a/executor/config.go
+++ b/executor/config.go
@@ -4,26 +4,32 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/blocklessnetwork/b7s/models/blockless"
+	"github.com/blocklessnetwork/b7s/models/execute"
 )
+
+type ExecutionSigner interface {
+	Sign(execute.Request, execute.RuntimeOutput) ([]byte, error)
+}
 
 // defaultConfig used to create Executor.
 var defaultConfig = Config{
-	WorkDir:        "workspace",
-	RuntimeDir:     "",
-	ExecutableName: blockless.RuntimeCLI(),
-	FS:             afero.NewOsFs(),
-	Limiter:        &noopLimiter{},
+	WorkDir:         "workspace",
+	RuntimeDir:      "",
+	ExecutableName:  blockless.RuntimeCLI(),
+	FS:              afero.NewOsFs(),
+	Limiter:         &noopLimiter{},
 	DriversRootPath: "",
 }
 
 // Config represents the Executor configuration.
 type Config struct {
-	WorkDir        string   // directory where files needed for the execution are stored
-	RuntimeDir     string   // directory where the executable can be found
-	ExecutableName string   // name for the executable
-	DriversRootPath string // where are cgi drivers stored
-	FS             afero.Fs // FS accessor
-	Limiter        Limiter  // Resource limiter for executed processes
+	WorkDir         string          // directory where files needed for the execution are stored
+	RuntimeDir      string          // directory where the executable can be found
+	ExecutableName  string          // name for the executable
+	DriversRootPath string          // where are cgi drivers stored
+	FS              afero.Fs        // FS accessor
+	Limiter         Limiter         // Resource limiter for executed processes
+	Signer          ExecutionSigner // Signer for the executor
 }
 
 type Option func(*Config)
@@ -60,5 +66,12 @@ func WithExecutableName(name string) Option {
 func WithLimiter(limiter Limiter) Option {
 	return func(cfg *Config) {
 		cfg.Limiter = limiter
+	}
+}
+
+// WithSigner sets the signer for the executor.
+func WithSigner(signer ExecutionSigner) Option {
+	return func(cfg *Config) {
+		cfg.Signer = signer
 	}
 }

--- a/models/blockless/executor.go
+++ b/models/blockless/executor.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Executor interface {
-	ExecuteFunction(requestID string, request execute.Request) (execute.Result, error)
+	ExecuteFunction(requestID string, request execute.Request) (execute.Result, any, error)
 }

--- a/models/execute/response.go
+++ b/models/execute/response.go
@@ -15,6 +15,7 @@ type Result struct {
 	Result    RuntimeOutput `json:"result"`
 	RequestID string        `json:"request_id"`
 	Usage     Usage         `json:"usage,omitempty"`
+	Signature []byte        `json:"signature,omitempty"`
 }
 
 // Cluster represents the set of peers that executed the request.

--- a/models/execute/response.go
+++ b/models/execute/response.go
@@ -16,6 +16,7 @@ type Result struct {
 	RequestID string        `json:"request_id"`
 	Usage     Usage         `json:"usage,omitempty"`
 	Signature []byte        `json:"signature,omitempty"`
+	Metadata  interface{}   `json:"metadata,omitempty"`
 }
 
 // Cluster represents the set of peers that executed the request.

--- a/models/execute/response.go
+++ b/models/execute/response.go
@@ -12,11 +12,15 @@ import (
 // Result describes an execution result.
 type Result struct {
 	Code      codes.Code    `json:"code"`
-	Result    RuntimeOutput `json:"result"`
+	Output    RuntimeOutput `json:"output"`
 	RequestID string        `json:"request_id"`
 	Usage     Usage         `json:"usage,omitempty"`
-	Signature []byte        `json:"signature,omitempty"`
-	Metadata  interface{}   `json:"metadata,omitempty"`
+}
+
+// NodeExecutionResult describes
+type NodeExecutionResult struct {
+	Result   `json:"execution_result"`
+	Metadata any `json:"metadata,omitempty"`
 }
 
 // Cluster represents the set of peers that executed the request.
@@ -42,7 +46,7 @@ type Usage struct {
 }
 
 // ResultMap contains execution results from multiple peers.
-type ResultMap map[peer.ID]Result
+type ResultMap map[peer.ID]NodeExecutionResult
 
 // MarshalJSON provides means to correctly handle JSON serialization/deserialization.
 // See:
@@ -51,7 +55,7 @@ type ResultMap map[peer.ID]Result
 //	https://github.com/libp2p/go-libp2p-resource-manager/pull/67#issuecomment-1176820561
 func (m ResultMap) MarshalJSON() ([]byte, error) {
 
-	em := make(map[string]Result, len(m))
+	em := make(map[string]NodeExecutionResult, len(m))
 	for p, v := range m {
 		em[p.String()] = v
 	}

--- a/models/execute/runtime.go
+++ b/models/execute/runtime.go
@@ -6,12 +6,12 @@ const (
 
 // RuntimeConfig represents the CLI flags supported by the runtime
 type BLSRuntimeConfig struct {
-	Entry         string `json:"entry,omitempty"`
-	ExecutionTime uint64 `json:"run_time,omitempty"`
-	DebugInfo     bool   `json:"debug_info,omitempty"`
-	Fuel          uint64 `json:"limited_fuel,omitempty"`
-	Memory        uint64 `json:"limited_memory,omitempty"`
-	Logger        string `json:"runtime_logger,omitempty"`
+	Entry           string `json:"entry,omitempty"`
+	ExecutionTime   uint64 `json:"run_time,omitempty"`
+	DebugInfo       bool   `json:"debug_info,omitempty"`
+	Fuel            uint64 `json:"limited_fuel,omitempty"`
+	Memory          uint64 `json:"limited_memory,omitempty"`
+	Logger          string `json:"runtime_logger,omitempty"`
 	DriversRootPath string `json:"drivers_root_path,omitempty"`
 	// Fields not allowed to be set in the request.
 	Input  string `json:"-"`
@@ -29,5 +29,5 @@ const (
 	BLSRuntimeFlagLogger        = "runtime-logger"
 	BLSRuntimeFlagPermission    = "permission"
 	BLSRuntimeFlagEnv           = "env"
-	BLSRuntimeFlagDrivers 		= "drivers-root-path"
+	BLSRuntimeFlagDrivers       = "drivers-root-path"
 )

--- a/models/response/execute_test.go
+++ b/models/response/execute_test.go
@@ -17,7 +17,7 @@ func TestExecute_Signing(t *testing.T) {
 		RequestID: mocks.GenericUUID.String(),
 		Code:      codes.OK,
 		Results: execute.ResultMap{
-			mocks.GenericPeerID: mocks.GenericExecutionResult,
+			mocks.GenericPeerID: execute.NodeExecutionResult{Result: mocks.GenericExecutionResult},
 		},
 		Cluster: execute.Cluster{
 			Peers: mocks.GenericPeerIDs[:4],

--- a/node/aggregate/aggregate.go
+++ b/node/aggregate/aggregate.go
@@ -19,12 +19,15 @@ type Result struct {
 	Frequency float64 `json:"frequency,omitempty"`
 	// Signature of this result
 	Signature []byte `json:"signature,omitempty"`
+	// Metadata is used to store additional information about the result.
+	Metadata interface{} `json:"metadata,omitempty"`
 }
 
 type resultStats struct {
 	seen      uint
 	peers     []peer.ID
 	signature []byte
+	metadata  interface{}
 }
 
 func Aggregate(results execute.ResultMap) Results {
@@ -46,12 +49,14 @@ func Aggregate(results execute.ResultMap) Results {
 				seen:      0,
 				peers:     make([]peer.ID, 0),
 				signature: res.Signature,
+				metadata:  res.Metadata,
 			}
 		}
 
 		stat.seen++
 		stat.peers = append(stat.peers, executingPeer)
 		stat.signature = res.Signature
+		stat.metadata = res.Metadata
 
 		stats[output] = stat
 	}
@@ -65,6 +70,7 @@ func Aggregate(results execute.ResultMap) Results {
 			Peers:     stat.peers,
 			Frequency: 100 * float64(stat.seen) / float64(total),
 			Signature: stat.signature,
+			Metadata:  stat.metadata,
 		}
 
 		aggregated = append(aggregated, aggr)

--- a/node/aggregate/aggregate.go
+++ b/node/aggregate/aggregate.go
@@ -17,17 +17,14 @@ type Result struct {
 	Peers []peer.ID `json:"peers,omitempty"`
 	// How frequent was this result, in percentages.
 	Frequency float64 `json:"frequency,omitempty"`
-	// Signature of this result
-	Signature []byte `json:"signature,omitempty"`
 	// Metadata is used to store additional information about the result.
-	Metadata interface{} `json:"metadata,omitempty"`
+	Metadata any `json:"metadata,omitempty"`
 }
 
 type resultStats struct {
-	seen      uint
-	peers     []peer.ID
-	signature []byte
-	metadata  interface{}
+	seen     uint
+	peers    []peer.ID
+	metadata any
 }
 
 func Aggregate(results execute.ResultMap) Results {
@@ -41,21 +38,19 @@ func Aggregate(results execute.ResultMap) Results {
 	for executingPeer, res := range results {
 
 		// NOTE: It might make sense to ignore stderr in comparison.
-		output := res.Result
+		output := res.Output
 
 		stat, ok := stats[output]
 		if !ok {
 			stats[output] = resultStats{
-				seen:      0,
-				peers:     make([]peer.ID, 0),
-				signature: res.Signature,
-				metadata:  res.Metadata,
+				seen:     0,
+				peers:    make([]peer.ID, 0),
+				metadata: res.Metadata,
 			}
 		}
 
 		stat.seen++
 		stat.peers = append(stat.peers, executingPeer)
-		stat.signature = res.Signature
 		stat.metadata = res.Metadata
 
 		stats[output] = stat
@@ -69,7 +64,6 @@ func Aggregate(results execute.ResultMap) Results {
 			Result:    res,
 			Peers:     stat.peers,
 			Frequency: 100 * float64(stat.seen) / float64(total),
-			Signature: stat.signature,
 			Metadata:  stat.metadata,
 		}
 

--- a/node/aggregate/aggregate.go
+++ b/node/aggregate/aggregate.go
@@ -17,11 +17,14 @@ type Result struct {
 	Peers []peer.ID `json:"peers,omitempty"`
 	// How frequent was this result, in percentages.
 	Frequency float64 `json:"frequency,omitempty"`
+	// Signature of this result
+	Signature []byte `json:"signature,omitempty"`
 }
 
 type resultStats struct {
-	seen  uint
-	peers []peer.ID
+	seen      uint
+	peers     []peer.ID
+	signature []byte
 }
 
 func Aggregate(results execute.ResultMap) Results {
@@ -40,13 +43,15 @@ func Aggregate(results execute.ResultMap) Results {
 		stat, ok := stats[output]
 		if !ok {
 			stats[output] = resultStats{
-				seen:  0,
-				peers: make([]peer.ID, 0),
+				seen:      0,
+				peers:     make([]peer.ID, 0),
+				signature: res.Signature,
 			}
 		}
 
 		stat.seen++
 		stat.peers = append(stat.peers, executingPeer)
+		stat.signature = res.Signature
 
 		stats[output] = stat
 	}
@@ -59,6 +64,7 @@ func Aggregate(results execute.ResultMap) Results {
 			Result:    res,
 			Peers:     stat.peers,
 			Frequency: 100 * float64(stat.seen) / float64(total),
+			Signature: stat.signature,
 		}
 
 		aggregated = append(aggregated, aggr)

--- a/node/consensus.go
+++ b/node/consensus.go
@@ -42,7 +42,7 @@ func (n *Node) createRaftCluster(ctx context.Context, from peer.ID, fc request.F
 			Code:      res.Code,
 			RequestID: req.RequestID,
 			Results: execute.ResultMap{
-				n.host.ID(): res,
+				n.host.ID(): execute.NodeExecutionResult{Result: res},
 			},
 		}
 

--- a/node/execution_results.go
+++ b/node/execution_results.go
@@ -30,7 +30,7 @@ func (n *Node) gatherExecutionResultsPBFT(ctx context.Context, requestID string,
 		wg    sync.WaitGroup
 
 		results                   = make(map[string]aggregatedResult)
-		out     execute.ResultMap = make(map[peer.ID]execute.Result)
+		out     execute.ResultMap = make(map[peer.ID]execute.NodeExecutionResult)
 	)
 
 	wg.Add(len(peers))
@@ -74,7 +74,7 @@ func (n *Node) gatherExecutionResultsPBFT(ctx context.Context, requestID string,
 			result, ok := results[reskey]
 			if !ok {
 				results[reskey] = aggregatedResult{
-					result: exres,
+					result: exres.Result,
 					peers: []peer.ID{
 						sender,
 					},
@@ -88,7 +88,7 @@ func (n *Node) gatherExecutionResultsPBFT(ctx context.Context, requestID string,
 				exCancel()
 
 				for _, peer := range result.peers {
-					out[peer] = result.result
+					out[peer] = execute.NodeExecutionResult{Result: result.result}
 				}
 			}
 		}(rp)
@@ -107,7 +107,7 @@ func (n *Node) gatherExecutionResults(ctx context.Context, requestID string, pee
 	defer exCancel()
 
 	var (
-		results execute.ResultMap = make(map[peer.ID]execute.Result)
+		results execute.ResultMap = make(map[peer.ID]execute.NodeExecutionResult)
 		reslock sync.Mutex
 		wg      sync.WaitGroup
 	)

--- a/node/worker_execute.go
+++ b/node/worker_execute.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -47,6 +48,7 @@ func (n *Node) workerProcessExecute(ctx context.Context, from peer.ID, req reque
 		Results: execute.ResultMap{
 			n.host.ID(): result,
 		},
+		Signature: hex.EncodeToString(result.Signature),
 	}
 
 	// Send the response, whatever it may be (success or failure).

--- a/testing/mocks/executor.go
+++ b/testing/mocks/executor.go
@@ -7,21 +7,21 @@ import (
 )
 
 type Executor struct {
-	ExecFunctionFunc func(string, execute.Request) (execute.Result, error)
+	ExecFunctionFunc func(string, execute.Request) (execute.Result, any, error)
 }
 
 func BaselineExecutor(t *testing.T) *Executor {
 	t.Helper()
 
 	executor := Executor{
-		ExecFunctionFunc: func(string, execute.Request) (execute.Result, error) {
-			return GenericExecutionResult, nil
+		ExecFunctionFunc: func(string, execute.Request) (execute.Result, any, error) {
+			return GenericExecutionResult, nil, nil
 		},
 	}
 
 	return &executor
 }
 
-func (e *Executor) ExecuteFunction(requestID string, req execute.Request) (execute.Result, error) {
+func (e *Executor) ExecuteFunction(requestID string, req execute.Request) (execute.Result, any, error) {
 	return e.ExecFunctionFunc(requestID, req)
 }

--- a/testing/mocks/generic.go
+++ b/testing/mocks/generic.go
@@ -33,7 +33,7 @@ var (
 
 	GenericExecutionResult = execute.Result{
 		Code: codes.Unknown,
-		Result: execute.RuntimeOutput{
+		Output: execute.RuntimeOutput{
 			Stdout:   "generic-execution-result",
 			Stderr:   "generic-execution-log",
 			ExitCode: 0,

--- a/testing/mocks/node.go
+++ b/testing/mocks/node.go
@@ -22,7 +22,7 @@ func BaselineNode(t *testing.T) *Node {
 		ExecuteFunctionFunc: func(context.Context, execute.Request, string) (codes.Code, string, execute.ResultMap, execute.Cluster, error) {
 
 			results := execute.ResultMap{
-				GenericPeerID: GenericExecutionResult,
+				GenericPeerID: execute.NodeExecutionResult{Result: GenericExecutionResult},
 			}
 
 			// TODO: Add a generic cluster info


### PR DESCRIPTION
# Context

This PR adds support for b7s workers to optionally injecting metadata in responses.

- This is specifically useful when using b7s node as a lib, where you'd want the worker to inject the response with custom provided metadata (such as in the case of using b7s as AVS)
- With this change, the head node would return aggregated worker responses, in addition to their respective metadata (assuming the workers opted into providing metadata)