### PR TITLE
Sending to many peers can be tolerant of failures

### DIFF
--- a/node/cluster.go
+++ b/node/cluster.go
@@ -78,7 +78,7 @@ func (n *Node) formCluster(ctx context.Context, requestID string, replicas []pee
 	}
 
 	// Request execution from peers.
-	err := n.sendToMany(ctx, replicas, reqCluster)
+	err := n.sendToMany(ctx, replicas, reqCluster, true)
 	if err != nil {
 		return fmt.Errorf("could not send cluster formation request to peers: %w", err)
 	}
@@ -142,7 +142,7 @@ func (n *Node) disbandCluster(requestID string, replicas []peer.ID) error {
 	ctx, cancel := context.WithTimeout(context.Background(), consensusClusterSendTimeout)
 	defer cancel()
 
-	err := n.sendToMany(ctx, replicas, msgDisband)
+	err := n.sendToMany(ctx, replicas, msgDisband, true)
 	if err != nil {
 		return fmt.Errorf("could not send cluster disband request (request: %s): %w", requestID, err)
 	}

--- a/node/head_execute.go
+++ b/node/head_execute.go
@@ -129,7 +129,11 @@ func (n *Node) headExecute(ctx context.Context, requestID string, req execute.Re
 		}
 	}
 
-	err = n.sendToMany(ctx, reportingPeers, reqExecute)
+	err = n.sendToMany(ctx,
+		reportingPeers,
+		reqExecute,
+		consensusRequired(consensusAlgo), // If we're using consensus, try to reach all peers.
+	)
 	if err != nil {
 		return codes.Error, nil, cluster, fmt.Errorf("could not send execution request to peers (function: %s, request: %s): %w", req.FunctionID, requestID, err)
 	}

--- a/node/message.go
+++ b/node/message.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 
@@ -63,8 +64,8 @@ func (n *Node) send(ctx context.Context, to peer.ID, msg blockless.Message) erro
 	return nil
 }
 
-// sendToMany serializes the message and sends it to a number of peers. It aborts on any error.
-func (n *Node) sendToMany(ctx context.Context, peers []peer.ID, msg blockless.Message) error {
+// sendToMany serializes the message and sends it to a number of peers. `requireAll` dictates how we treat partial errors.
+func (n *Node) sendToMany(ctx context.Context, peers []peer.ID, msg blockless.Message, requireAll bool) error {
 
 	// Serialize the message.
 	payload, err := json.Marshal(msg)
@@ -72,15 +73,40 @@ func (n *Node) sendToMany(ctx context.Context, peers []peer.ID, msg blockless.Me
 		return fmt.Errorf("could not encode record: %w", err)
 	}
 
+	var errGroup multierror.Group
 	for i, peer := range peers {
-		// Send message.
-		err = n.host.SendMessage(ctx, peer, payload)
-		if err != nil {
-			return fmt.Errorf("could not send message to peer (id: %v, peer %d out of %d): %w", peer, i, len(peers), err)
-		}
+		i := i
+		peer := peer
+
+		errGroup.Go(func() error {
+			err := n.host.SendMessage(ctx, peer, payload)
+			if err != nil {
+				return fmt.Errorf("peer %v/%v send error (peer: %v): %w", i, len(peers), peer.String(), err)
+			}
+
+			return nil
+		})
 	}
 
-	return nil
+	retErr := errGroup.Wait()
+	if retErr == nil || len(retErr.Errors) == 0 {
+		// If everything succeeded => ok.
+		return nil
+	}
+
+	switch len(retErr.Errors) {
+	case len(peers):
+		// If everything failed => error.
+		return fmt.Errorf("all sends failed: %w", retErr)
+
+	default:
+		// Some sends failed - do as requested by `requireAll`.
+		if requireAll {
+			return fmt.Errorf("some sends failed: %w", retErr)
+		}
+
+		return nil
+	}
 }
 
 func (n *Node) publish(ctx context.Context, msg blockless.Message) error {

--- a/node/message.go
+++ b/node/message.go
@@ -81,7 +81,7 @@ func (n *Node) sendToMany(ctx context.Context, peers []peer.ID, msg blockless.Me
 		errGroup.Go(func() error {
 			err := n.host.SendMessage(ctx, peer, payload)
 			if err != nil {
-				return fmt.Errorf("peer %v/%v send error (peer: %v): %w", i, len(peers), peer.String(), err)
+				return fmt.Errorf("peer %v/%v send error (peer: %v): %w", i+1, len(peers), peer.String(), err)
 			}
 
 			return nil
@@ -104,6 +104,8 @@ func (n *Node) sendToMany(ctx context.Context, peers []peer.ID, msg blockless.Me
 		if requireAll {
 			return fmt.Errorf("some sends failed: %w", retErr)
 		}
+
+		n.log.Warn().Err(retErr).Msg("some sends failed, proceeding")
 
 		return nil
 	}

--- a/node/message_internal_test.go
+++ b/node/message_internal_test.go
@@ -3,11 +3,13 @@ package node
 import (
 	"context"
 	"encoding/json"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 
 	"github.com/blocklessnetwork/b7s/host"
@@ -15,19 +17,7 @@ import (
 	"github.com/blocklessnetwork/b7s/testing/mocks"
 )
 
-func TestNode_Messaging(t *testing.T) {
-
-	const (
-		topic = DefaultTopic
-	)
-
-	var (
-		rec = dummyRecord{
-			ID:          mocks.GenericUUID.String(),
-			Value:       19846,
-			Description: "dummy-description",
-		}
-	)
+func TestNode_SendMessage(t *testing.T) {
 
 	client, err := host.New(mocks.NoopLogger, loopback, 0)
 	require.NoError(t, err)
@@ -35,70 +25,115 @@ func TestNode_Messaging(t *testing.T) {
 	node := createNode(t, blockless.HeadNode)
 	hostAddNewPeer(t, node.host, client)
 
-	t.Run("sending single message", func(t *testing.T) {
-		t.Parallel()
+	rec := newDummyRecord()
 
-		var wg sync.WaitGroup
-		wg.Add(1)
+	var wg sync.WaitGroup
+	wg.Add(1)
 
-		client.SetStreamHandler(blockless.ProtocolID, func(stream network.Stream) {
-			defer wg.Done()
-			defer stream.Close()
+	client.SetStreamHandler(blockless.ProtocolID, func(stream network.Stream) {
+		defer wg.Done()
+		defer stream.Close()
 
-			from := stream.Conn().RemotePeer()
-			require.Equal(t, node.host.ID(), from)
-
-			var received dummyRecord
-			getStreamPayload(t, stream, &received)
-
-			require.Equal(t, rec, received)
-		})
-
-		err := node.send(context.Background(), client.ID(), rec)
-		require.NoError(t, err)
-
-		wg.Wait()
-	})
-	t.Run("publishing to a topic", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := context.Background()
-
-		err = client.InitPubSub(ctx)
-		require.NoError(t, err)
-
-		// Establish a connection between peers.
-		clientInfo := hostGetAddrInfo(t, client)
-		err = node.host.Connect(ctx, *clientInfo)
-		require.NoError(t, err)
-
-		// Have both client and node subscribe to the same topic.
-		_, subscription, err := client.Subscribe(topic)
-		require.NoError(t, err)
-
-		err = node.subscribeToTopics(ctx)
-		require.NoError(t, err)
-
-		time.Sleep(subscriptionDiseminationPause)
-
-		err = node.publish(ctx, rec)
-		require.NoError(t, err)
-
-		deadlineCtx, cancel := context.WithTimeout(ctx, publishTimeout)
-		defer cancel()
-		msg, err := subscription.Next(deadlineCtx)
-		require.NoError(t, err)
-
-		from := msg.ReceivedFrom
+		from := stream.Conn().RemotePeer()
 		require.Equal(t, node.host.ID(), from)
-		require.NotNil(t, msg.Topic)
-		require.Equal(t, topic, *msg.Topic)
 
 		var received dummyRecord
-		err = json.Unmarshal(msg.Data, &received)
-		require.NoError(t, err)
+		getStreamPayload(t, stream, &received)
 
 		require.Equal(t, rec, received)
+	})
+
+	err = node.send(context.Background(), client.ID(), rec)
+	require.NoError(t, err)
+
+	wg.Wait()
+}
+
+func TestNode_Publish(t *testing.T) {
+
+	var (
+		rec   = newDummyRecord()
+		ctx   = context.Background()
+		topic = DefaultTopic
+	)
+
+	client, err := host.New(mocks.NoopLogger, loopback, 0)
+	require.NoError(t, err)
+
+	err = client.InitPubSub(ctx)
+	require.NoError(t, err)
+
+	node := createNode(t, blockless.HeadNode)
+	hostAddNewPeer(t, node.host, client)
+
+	err = node.subscribeToTopics(ctx)
+	require.NoError(t, err)
+
+	// Establish a connection between peers.
+	clientInfo := hostGetAddrInfo(t, client)
+	err = node.host.Connect(ctx, *clientInfo)
+	require.NoError(t, err)
+
+	// Have both client and node subscribe to the same topic.
+	_, subscription, err := client.Subscribe(topic)
+	require.NoError(t, err)
+
+	time.Sleep(subscriptionDiseminationPause)
+
+	err = node.publish(ctx, rec)
+	require.NoError(t, err)
+
+	deadlineCtx, cancel := context.WithTimeout(ctx, publishTimeout)
+	defer cancel()
+	msg, err := subscription.Next(deadlineCtx)
+	require.NoError(t, err)
+
+	from := msg.ReceivedFrom
+	require.Equal(t, node.host.ID(), from)
+	require.NotNil(t, msg.Topic)
+	require.Equal(t, topic, *msg.Topic)
+
+	var received dummyRecord
+	err = json.Unmarshal(msg.Data, &received)
+	require.NoError(t, err)
+	require.Equal(t, rec, received)
+}
+
+func TestNode_SendMessageToMany(t *testing.T) {
+
+	client1, err := host.New(mocks.NoopLogger, loopback, 0)
+	require.NoError(t, err)
+
+	client2, err := host.New(mocks.NoopLogger, loopback, 0)
+	require.NoError(t, err)
+
+	node := createNode(t, blockless.HeadNode)
+	hostAddNewPeer(t, node.host, client1)
+	hostAddNewPeer(t, node.host, client2)
+
+	client1.SetStreamHandler(blockless.ProtocolID, func(network.Stream) {})
+	client2.SetStreamHandler(blockless.ProtocolID, func(network.Stream) {})
+
+	// NOTE: These subtests are sequential.
+	t.Run("nominal case - sending to two online peers is ok", func(t *testing.T) {
+		err = node.sendToMany(context.Background(), []peer.ID{client1.ID(), client2.ID()}, newDummyRecord(), true)
+		require.NoError(t, err)
+	})
+	t.Run("peer is down with requireAll is an error", func(t *testing.T) {
+		client1.Close()
+		err = node.sendToMany(context.Background(), []peer.ID{client1.ID(), client2.ID()}, newDummyRecord(), true)
+		require.Error(t, err)
+	})
+	t.Run("peer is down with partial delivery is ok", func(t *testing.T) {
+		client1.Close()
+		err = node.sendToMany(context.Background(), []peer.ID{client1.ID(), client2.ID()}, newDummyRecord(), false)
+		require.NoError(t, err)
+	})
+	t.Run("all sends failing produces an error", func(t *testing.T) {
+		client1.Close()
+		client2.Close()
+		err = node.sendToMany(context.Background(), []peer.ID{client1.ID(), client2.ID()}, newDummyRecord(), false)
+		require.Error(t, err)
 	})
 }
 
@@ -110,4 +145,12 @@ type dummyRecord struct {
 
 func (dummyRecord) Type() string {
 	return "MessageDummyRecord"
+}
+
+func newDummyRecord() dummyRecord {
+	return dummyRecord{
+		ID:          mocks.GenericUUID.String(),
+		Value:       rand.Uint64(),
+		Description: "dummy-description",
+	}
 }


### PR DESCRIPTION
This PR makes a slight change to how `sendToMany()` operates.

Before, we were strict in how we treat errors - failing to send message even to a single peer meant we treated the whole operation as a failure. Also, if send to n-th peer failed - we did not even try peers that are after it in the list.

This caused problems in cases where we might have flaky peers that do reply to a roll call but might drop off afterwards, pulling down the whole operation with it. Additionally, we were sending messages sequentially.

Now, we parallelize sends, and also tolerate partial send failures, similar to how we treat waiting for execution responses - we might not get everyone. This goes for non-consensus executions at the moment. For consensus we still require all peers get the message.

Also - if ALL sends fail - we do treat that as an error.