### PR TITLE
Cluster discoverability improvement - include addresses of the replicas

### DIFF
--- a/models/request/form_cluster.go
+++ b/models/request/form_cluster.go
@@ -14,9 +14,10 @@ var _ (json.Marshaler) = (*FormCluster)(nil)
 // FormCluster describes the `MessageFormCluster` request payload.
 // It is sent on clustered execution of a request.
 type FormCluster struct {
-	RequestID string         `json:"request_id,omitempty"`
-	Peers     []peer.ID      `json:"peers,omitempty"`
-	Consensus consensus.Type `json:"consensus,omitempty"`
+	RequestID      string          `json:"request_id,omitempty"`
+	Peers          []peer.ID       `json:"peers,omitempty"`
+	Consensus      consensus.Type  `json:"consensus,omitempty"`
+	ConnectionInfo []peer.AddrInfo `json:"connection_info,omitempty"`
 }
 
 func (FormCluster) Type() string { return blockless.MessageFormCluster }

--- a/node/execution_results.go
+++ b/node/execution_results.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/rs/zerolog/log"
 
 	"github.com/blocklessnetwork/b7s/consensus/pbft"
 	"github.com/blocklessnetwork/b7s/models/execute"
@@ -52,13 +51,13 @@ func (n *Node) gatherExecutionResultsPBFT(ctx context.Context, requestID string,
 
 			pub, err := sender.ExtractPublicKey()
 			if err != nil {
-				log.Error().Err(err).Msg("could not derive public key from peer ID")
+				n.log.Error().Err(err).Msg("could not derive public key from peer ID")
 				return
 			}
 
 			err = er.VerifySignature(pub)
 			if err != nil {
-				log.Error().Err(err).Msg("could not verify signature of an execution response")
+				n.log.Error().Err(err).Msg("could not verify signature of an execution response")
 				return
 			}
 

--- a/node/params.go
+++ b/node/params.go
@@ -15,6 +15,8 @@ const (
 	DefaultClusterFormationTimeout = 10 * time.Second
 	DefaultConcurrency             = 10
 
+	ClusterAddressTTL = 30 * time.Minute
+
 	DefaultConsensusAlgorithm = consensus.Raft
 
 	DefaultAttributeLoadingSetting = false

--- a/node/run.go
+++ b/node/run.go
@@ -86,7 +86,7 @@ func (n *Node) Run(ctx context.Context) error {
 					continue
 				}
 
-				n.log.Trace().Str("topic", name).Str("peer", msg.ReceivedFrom.String()).Str("id", msg.ID).Msg("received message")
+				n.log.Trace().Str("topic", name).Str("peer", msg.ReceivedFrom.String()).Hex("id", []byte(msg.ID)).Msg("received message")
 
 				// Try to get a slot for processing the request.
 				n.sema <- struct{}{}


### PR DESCRIPTION
This PR makes a slight change to consensus cluster formation.

Worker nodes can form a cluster in order to achieve consensus about an execution, when instructed to do so by the head node.
However, it might be the case that workers have never seen each other before, and don't know the addresses where they could reach their fellow workers.

Now, head node includes the multiaddresses of the peers chosen to form a consensus in the `FormCluster` message payload. Workers receiving this message will add these addresses to their address book, if they do not know of the peer already, That way when the consensus communication starts, they'll know how to reach their fellow replicas.