### PR TITLE
Increase the limit of open libp2p connections

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -12,6 +12,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -49,12 +50,19 @@ func New(log zerolog.Logger, address string, port uint, options ...func(*Config)
 		addresses = append(addresses, wsAddr)
 	}
 
+	// By default the connection manager will prune connections each 10 seconds, while new connections are spared from pruning for the initial 1 minute.
+	cm, err := connmgr.NewConnManager(connLimitLo, connLimitHi)
+	if err != nil {
+		return nil, fmt.Errorf("could not create new connection manager: %w", err)
+	}
+
 	opts := []libp2p.Option{
 		libp2p.ListenAddrStrings(addresses...),
 		libp2p.DefaultTransports,
 		libp2p.DefaultMuxers,
 		libp2p.DefaultSecurity,
 		libp2p.NATPortMap(),
+		libp2p.ConnectionManager(cm),
 	}
 
 	// Read private key, if provided.

--- a/host/params.go
+++ b/host/params.go
@@ -5,4 +5,9 @@ const (
 	errNoGoodAddresses = "no good addresses"
 
 	defaultMustReachBootNodes = false
+
+	// When we reach this number of connections, we'll prune open connections.
+	connLimitHi = 1024
+	// Number of connections we will leave after pruning.
+	connLimitLo = 768
 )


### PR DESCRIPTION
This PR increases the number of open connections we tolerate. Default libp2p connection manager will prune open connections on each 10 seconds. If the number of connections is over 192, connections will be terminated until there are 160 connections open. Connections are spared from pruning for the initial minute.

This PR explicitly creates a connection manager that alters these limits by setting the limits to 1024/768.