### PR TITLE
Add a config option to disable libp2p resource limits

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -128,6 +128,7 @@ func run() int {
 		host.WithWebsocket(cfg.Connectivity.Websocket),
 		host.WithWebsocketPort(cfg.Connectivity.WebsocketPort),
 		host.WithMustReachBootNodes(cfg.Connectivity.MustReachBootNodes),
+		host.WithDisabledResourceLimits(cfg.Connectivity.DisableConnectionLimits),
 	}
 
 	if !cfg.Connectivity.NoDialbackPeers {

--- a/config/config.go
+++ b/config/config.go
@@ -59,16 +59,17 @@ type Log struct {
 
 // Connectivity describes the libp2p host that the node will use.
 type Connectivity struct {
-	Address               string `koanf:"address"                 flag:"address,a"`
-	Port                  uint   `koanf:"port"                    flag:"port,p"`
-	PrivateKey            string `koanf:"private-key"             flag:"private-key"`
-	DialbackAddress       string `koanf:"dialback-address"        flag:"dialback-address"`
-	DialbackPort          uint   `koanf:"dialback-port"           flag:"dialback-port"`
-	Websocket             bool   `koanf:"websocket"               flag:"websocket,w"`
-	WebsocketPort         uint   `koanf:"websocket-port"          flag:"websocket-port"`
-	WebsocketDialbackPort uint   `koanf:"websocket-dialback-port" flag:"websocket-dialback-port"`
-	NoDialbackPeers       bool   `koanf:"no-dialback-peers"       flag:"no-dialback-peers"`
-	MustReachBootNodes    bool   `koanf:"must-reach-boot-nodes"   flag:"must-reach-boot-nodes"`
+	Address                 string `koanf:"address"                   flag:"address,a"`
+	Port                    uint   `koanf:"port"                      flag:"port,p"`
+	PrivateKey              string `koanf:"private-key"               flag:"private-key"`
+	DialbackAddress         string `koanf:"dialback-address"          flag:"dialback-address"`
+	DialbackPort            uint   `koanf:"dialback-port"             flag:"dialback-port"`
+	Websocket               bool   `koanf:"websocket"                 flag:"websocket,w"`
+	WebsocketPort           uint   `koanf:"websocket-port"            flag:"websocket-port"`
+	WebsocketDialbackPort   uint   `koanf:"websocket-dialback-port"   flag:"websocket-dialback-port"`
+	NoDialbackPeers         bool   `koanf:"no-dialback-peers"         flag:"no-dialback-peers"`
+	MustReachBootNodes      bool   `koanf:"must-reach-boot-nodes"     flag:"must-reach-boot-nodes"`
+	DisableConnectionLimits bool   `koanf:"disable-connection-limits" flag:"disable-connection-limits"`
 }
 
 type Head struct {
@@ -142,6 +143,8 @@ func getFlagDescription(flag string) string {
 		return "start without dialing back peers from previous runs"
 	case "must-reach-boot-nodes":
 		return "halt node if we fail to reach boot nodes on start"
+	case "disable-connection-limits":
+		return "disable libp2p connection limits (experimental)"
 	default:
 		return ""
 	}

--- a/host/config.go
+++ b/host/config.go
@@ -38,6 +38,7 @@ type Config struct {
 
 	BootNodesReachabilityCheckInterval time.Duration
 	MustReachBootNodes                 bool
+	DisableResourceLimits              bool
 }
 
 // WithPrivateKey specifies the private key for the Host.
@@ -125,5 +126,13 @@ func WithMustReachBootNodes(b bool) func(*Config) {
 func WithBootNodesReachabilityInterval(d time.Duration) func(cfg *Config) {
 	return func(cfg *Config) {
 		cfg.BootNodesReachabilityCheckInterval = d
+	}
+}
+
+// WithDisabledResourceLimits allows removing any resource limits set by libp2p.
+// WARNING: experimental
+func WithDisabledResourceLimits(b bool) func(cfg *Config) {
+	return func(cfg *Config) {
+		cfg.DisableResourceLimits = b
 	}
 }

--- a/host/host.go
+++ b/host/host.go
@@ -12,6 +12,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -55,6 +56,15 @@ func New(log zerolog.Logger, address string, port uint, options ...func(*Config)
 		libp2p.DefaultMuxers,
 		libp2p.DefaultSecurity,
 		libp2p.NATPortMap(),
+	}
+
+	if cfg.DisableResourceLimits {
+		rcmgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.InfiniteLimits))
+		if err != nil {
+			return nil, fmt.Errorf("could not create new resource manager: %w", err)
+		}
+
+		opts = append(opts, libp2p.ResourceManager(rcmgr))
 	}
 
 	// Read private key, if provided.


### PR DESCRIPTION
This PR adds a config option to disable libp2p connection limits.
To be used with caution and will ideally be a temporary measure.