### PR TITLE
Fix PBFT results accounting

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Type identifies consensus protocols suported by Blockless.
@@ -30,4 +31,21 @@ func (t Type) Valid() bool {
 	default:
 		return false
 	}
+}
+
+func Parse(s string) (Type, error) {
+
+	if s == "" {
+		return 0, nil
+	}
+
+	switch strings.ToLower(s) {
+	case "raft":
+		return Raft, nil
+
+	case "pbft":
+		return PBFT, nil
+	}
+
+	return 0, fmt.Errorf("unknown consensus value (%s)", s)
 }

--- a/models/request/execute.go
+++ b/models/request/execute.go
@@ -2,8 +2,11 @@ package request
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
+	"github.com/blocklessnetwork/b7s/consensus"
+	"github.com/blocklessnetwork/b7s/consensus/pbft"
 	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/models/codes"
 	"github.com/blocklessnetwork/b7s/models/execute"
@@ -43,4 +46,20 @@ func (e Execute) MarshalJSON() ([]byte, error) {
 		Type:  e.Type(),
 	}
 	return json.Marshal(rec)
+}
+
+func (e Execute) Valid() error {
+
+	c, err := consensus.Parse(e.Config.ConsensusAlgorithm)
+	if err != nil {
+		return fmt.Errorf("could not parse consensus algorithm: %w", err)
+	}
+
+	if c == consensus.PBFT &&
+		e.Config.NodeCount > 0 &&
+		e.Config.NodeCount < pbft.MinimumReplicaCount {
+		return fmt.Errorf("minimum %v nodes needed for PBFT consensus", pbft.MinimumReplicaCount)
+	}
+
+	return nil
 }

--- a/models/response/execute.go
+++ b/models/response/execute.go
@@ -30,7 +30,7 @@ type Execute struct {
 	Signature string `json:"signature,omitempty"`
 
 	// Used to communicate the reason for failure to the user.
-	Message string `json:"message,omitempty"`
+	ErrorMessage string `json:"message,omitempty"`
 }
 
 func (e *Execute) WithResults(r execute.ResultMap) *Execute {
@@ -40,6 +40,11 @@ func (e *Execute) WithResults(r execute.ResultMap) *Execute {
 
 func (e *Execute) WithCluster(c execute.Cluster) *Execute {
 	e.Cluster = c
+	return e
+}
+
+func (e *Execute) WithErrorMessage(err error) *Execute {
+	e.ErrorMessage = err.Error()
 	return e
 }
 

--- a/node/execution_results.go
+++ b/node/execution_results.go
@@ -89,6 +89,8 @@ func (n *Node) gatherExecutionResultsPBFT(ctx context.Context, requestID string,
 			result.peers = append(result.peers, sender)
 			result.metadata[sender] = exres.Metadata
 
+			results[reskey] = result
+
 			if uint(len(result.peers)) >= count {
 				n.log.Info().Str("request", requestID).Int("peers", len(peers)).Uint("matching_results", count).Msg("have enough matching results")
 				exCancel()


### PR DESCRIPTION
This PR fixes how the head node accounts for PBFT results from cluster replicas, when aggregating results. The head node expects f+1 identical results, where f is the number of faulty replicas in a PBFT cluster.

We were not properly updating the map where we're aggregating the results coming from the nodes, which manifested when running PBFT consensus on >= 7 nodes.

Also, some clarity improvements - worker nodes refuse to join a PBFT cluster with less than four nodes. However, the head node does not vet the incoming execution request that this threshold is met.

Not, head node will discard execution requests that:
a) request PBFT consensus and have the number of nodes explicitly set to a value <= 4
b) request PBFT consensus with an unspecified number of nodes (-1, whoever comes can join), but less than 4 nodes apply to a roll call

