### PR TITLE
Update function_manifest_spec.md

### DIFF
--- a/docs/function_manifest_spec.md
+++ b/docs/function_manifest_spec.md
@@ -15,14 +15,14 @@ this is the `json` specification for the manifests that describe how a function 
     // version of the function
     "version": "1.0.0",
 
-    // whats the runtime specification
+    // what's the runtime specification
     "runtime": "<1.0.0",
 
     // what extensions are needed to run this function
     "extensions": ["foundation/ipfs/>=1.0.0"]
   },
   "deployment": {
-    // a manifest can provide a CID meaning its
+    // a manifest can provide a CID meaning it's
     // been stored on filecoin
     // we will try to use multiple known filecoin portals
     // to retrieve the package


### PR DESCRIPTION
Changes Made in docs/function_manifest_spec.md
1. Correction of "whats" to "what's"
Old: // whats the runtime specification
New: // what's the runtime specification
Reason: The word "whats" was corrected to "what's" to properly use the contraction for "what is," which is grammatically correct.
Correction of "its" to "it's"
Old: // a manifest can provide a CID meaning its
New: // a manifest can provide a CID meaning it's
Reason: The word "its" was corrected to "it's" to properly use the contraction for "it is," which is grammatically correct.
These changes improve the grammatical accuracy of the documentation, making it clearer and more professional.