### PR TITLE
README.md

### DIFF
--- a/cmd/bootstrap-limiter/README.md
+++ b/cmd/bootstrap-limiter/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 This utility is aimed to provide an easy way to setup the system so that a non-privileged user can set resource limits for Blockless Functions.
-This tool is designed to be run a single time, before runing the Blockless Worker Node.
+This tool is designed to be run a single time, before running the Blockless Worker Node.
 If the user has no intention of using cgroups to set resource limits, there is no need in running this tool.
 
 ## Workaround


### PR DESCRIPTION
# Fix README.md

## Summary
Corrected a typo in the `README.md` file to improve clarity and correctness.

## Motivation
Fixing this typo ensures the documentation is clear and professional for users and contributors.

## Changes
- Updated `README.md`:
  - Corrected "runing" to "running" in the following line:
    ```markdown
    This tool is designed to be run a single time, before running the Blockless Worker Node.
    ```

## Testing
- Reviewed the `README.md` to confirm the typo was fixed.
- No further changes were required.

## Checklist
- [x] Typo corrected in the documentation.
- [ ] No additional updates needed.

---

<!-- Contributions are in accordance with the project's security policy. -->
